### PR TITLE
Add calculatedPay attribute with PayCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/PayCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PayCommand.java
@@ -1,0 +1,92 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.HoursWorked;
+import seedu.address.model.person.Leaves;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.Role;
+import seedu.address.model.person.Salary;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Pays a person identified using it's displayed index from the address book.
+ */
+public class PayCommand extends Command {
+
+    public static final String COMMAND_WORD = "pay";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": marks the employee identified by the index number used in the displayed person list as paid.\n"
+            + "This also removes the calculated pay from being shown on the employee.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_PAY_PERSON_SUCCESS = "Successfully marked as paid: %1$s";
+
+    private final Index targetIndex;
+
+    public PayCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToPay = lastShownList.get(targetIndex.getZeroBased());
+        Person paidPerson = createPaidPerson(personToPay);
+        model.setPerson(personToPay, paidPerson);
+        return new CommandResult(String.format(MESSAGE_PAY_PERSON_SUCCESS, personToPay));
+    }
+
+    /**
+     * Creates and returns a {@code Person} with the details of {@code personToPay}
+     * with their calculated pay being set to 0.
+     * Essentially the same as paying the person.
+     *
+     * @param personToPay Employee to be paid
+     */
+    private static Person createPaidPerson(Person personToPay) {
+        assert personToPay != null;
+
+        Name name = personToPay.getName();
+        Phone phone = personToPay.getPhone();
+        Email email = personToPay.getEmail();
+        Address address = personToPay.getAddress();
+        Role role = personToPay.getRole();
+        Leaves leaves = personToPay.getLeaves();
+
+        // Create new salary with same value, with CalculatedPay initialized at 0
+        int value = personToPay.getSalary().value;
+        Salary paidSalary = new Salary(Integer.toString(value));
+
+        HoursWorked hours = personToPay.getHoursWorked();
+        Set<Tag> tags = personToPay.getTags();
+
+        return new Person(name, phone, email, address, role, leaves, paidSalary, hours, tags);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PayCommand // instanceof handles nulls
+                && targetIndex.equals(((PayCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.PayCommand;
 import seedu.address.logic.commands.RemoveLeavesCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -79,6 +80,9 @@ public class AddressBookParser {
 
         case CalculatePayCommand.COMMAND_WORD:
             return new CalculatePayCommandParser().parse(arguments);
+
+        case PayCommand.COMMAND_WORD:
+            return new PayCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/PayCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/PayCommandParser.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.PayCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+public class PayCommandParser implements Parser<PayCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the PayCommand
+     * and returns a PayCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    @Override
+    public PayCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new PayCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PayCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -31,6 +31,7 @@ public class Person {
     private final HoursWorked hoursWorked;
     private final Overtime overtime;
 
+
     /**
      * Constructs a {@code Person} object.
      * All fields except for overtime must be present and not null.
@@ -95,6 +96,14 @@ public class Person {
 
     public Salary getSalary() {
         return salary;
+    }
+
+    public int getCalculatedPay() {
+        return salary.getCalculatedPay();
+    }
+
+    public boolean isPaid() {
+        return salary.getCalculatedPay() > 0;
     }
 
     public HoursWorked getHoursWorked() {

--- a/src/main/java/seedu/address/model/person/Salary.java
+++ b/src/main/java/seedu/address/model/person/Salary.java
@@ -12,7 +12,11 @@ public class Salary {
     public static final String MESSAGE_CONSTRAINTS =
             "Salary should only contain positive integers, and it should not be blank";
 
+    public static final String CALC_PAY_ERROR =
+            "Calculated pay should only contain non-negative values!";
+
     public final int value;
+    public final int calculatedPay;
 
     /**
      * Constructs a {@code Salary}.
@@ -23,6 +27,21 @@ public class Salary {
         requireNonNull(amount);
         checkArgument(isValidSalary(amount), MESSAGE_CONSTRAINTS);
         this.value = Integer.parseInt(amount);
+        // calculatedPay initialized to 0
+        this.calculatedPay = 0;
+    }
+
+    /**
+     * Overloaded method to take into account calculated pay
+     * @param amount A valid salary amount.
+     * @param calculatedPay Calculated pay based on calculate function, 0 if paid.
+     */
+    public Salary(String amount, int calculatedPay) {
+        requireNonNull(amount);
+        checkArgument(isValidSalary(amount), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidCalculatedPay(calculatedPay), CALC_PAY_ERROR);
+        this.value = Integer.parseInt(amount);
+        this.calculatedPay = calculatedPay;
     }
 
     /**
@@ -37,6 +56,16 @@ public class Salary {
         }
     }
 
+    /**
+     * Check if calculated pay is non-negative.
+     */
+    public static boolean isValidCalculatedPay(int test) {
+        return test >= 0;
+    }
+
+    public int getCalculatedPay() {
+        return this.calculatedPay;
+    }
 
     @Override
     public String toString() {
@@ -47,7 +76,8 @@ public class Salary {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Salary // instanceof handles nulls
-                && value == ((Salary) other).value); // state check
+                && value == ((Salary) other).value)
+                && calculatedPay == ((Salary) other).getCalculatedPay(); // state checks
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -38,6 +38,7 @@ class JsonAdaptedPerson {
     private final String salary;
     private final String hoursWorked;
     private final String overtime;
+    private final String calculatedPay;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
 
     /**
@@ -48,7 +49,8 @@ class JsonAdaptedPerson {
             @JsonProperty("email") String email, @JsonProperty("address") String address,
             @JsonProperty("role") String role, @JsonProperty("leaves") String leaves,
             @JsonProperty("salary") String salary, @JsonProperty("hoursWorked") String hoursWorked,
-            @JsonProperty("overtime") String overtime, @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+            @JsonProperty("overtime") String overtime, @JsonProperty("calculatedPay") String calculatedPay,
+            @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -58,6 +60,7 @@ class JsonAdaptedPerson {
         this.salary = salary;
         this.hoursWorked = hoursWorked;
         this.overtime = overtime;
+        this.calculatedPay = calculatedPay;
         if (tagged != null) {
             this.tagged.addAll(tagged);
         }
@@ -76,6 +79,7 @@ class JsonAdaptedPerson {
         salary = source.getSalary().toString();
         hoursWorked = source.getHoursWorked().toString();
         overtime = source.getOvertime().toString();
+        calculatedPay = Integer.toString(source.getSalary().getCalculatedPay());
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -146,7 +150,8 @@ class JsonAdaptedPerson {
         if (!Salary.isValidSalary(salary)) {
             throw new IllegalValueException(Salary.MESSAGE_CONSTRAINTS);
         }
-        final Salary modelSalary = new Salary(salary);
+        // Also takes into account the calculatedPay
+        final Salary modelSalary = new Salary(salary, Integer.parseInt(calculatedPay));
 
         if (hoursWorked == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
@@ -165,6 +170,7 @@ class JsonAdaptedPerson {
             throw new IllegalValueException(Overtime.MESSAGE_CONSTRAINTS);
         }
         final Overtime modelOvertime = new Overtime(overtime);
+
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
         return new Person(modelName, modelPhone, modelEmail, modelAddress, modelRole, modelLeaves,


### PR DESCRIPTION
Implemented `calculatedPay` as an element in Salary, and can be accessed with its get method. Since `Salary` is immutable, `calculatedPay` is set to be final.
With this implementation, setting the `calculatedPay` of a person is done by creating a new person with a new `Salary` created with the overloaded constructor method that takes in  a `calculatedPay` argument and replaces the person to be paid with the new person.
This is also done for the `PayCommand` implementation, which takes in the index and sets the `calculatedPay` of a person to 0.

Resolved #49 