### PR TITLE
Add CalculatedPay attribute and PayCommand 

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddLeavesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLeavesCommand.java
@@ -54,7 +54,7 @@ public class AddLeavesCommand extends Command {
         Person editedPerson = new Person(
                 personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(), personToEdit.getAddress(),
                 personToEdit.getRole(), personToEdit.getLeaves().addLeaves(leave), personToEdit.getSalary(),
-                personToEdit.getHoursWorked(), personToEdit.getTags());
+                personToEdit.getHoursWorked(), personToEdit.getCalculatedPay(), personToEdit.getTags());
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -24,6 +24,7 @@ import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.CalculatedPay;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.HourlySalary;
 import seedu.address.model.person.HoursWorked;
@@ -113,10 +114,12 @@ public class EditCommand extends Command {
         Leave updatedLeave = editPersonDescriptor.getLeaves().orElse(personToEdit.getLeaves());
         HourlySalary updatedHourlySalary = editPersonDescriptor.getSalary().orElse(personToEdit.getSalary());
         HoursWorked updatedHours = editPersonDescriptor.getHoursWorked().orElse(personToEdit.getHoursWorked());
+        CalculatedPay updatedCalculatedPay =
+                editPersonDescriptor.getCalculatedPay().orElse(personToEdit.getCalculatedPay());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress,
-                updatedRole, updatedLeave, updatedHourlySalary, updatedHours, updatedTags);
+                updatedRole, updatedLeave, updatedHourlySalary, updatedHours, updatedCalculatedPay, updatedTags);
     }
 
     @Override
@@ -150,6 +153,7 @@ public class EditCommand extends Command {
         private Leave leave;
         private HourlySalary hourlySalary;
         private HoursWorked hoursWorked;
+        private CalculatedPay calculatedPay;
 
         private Set<Tag> tags;
 
@@ -168,6 +172,7 @@ public class EditCommand extends Command {
             setLeaves(toCopy.leave);
             setSalary(toCopy.hourlySalary);
             setHoursWorked(toCopy.hoursWorked);
+            setCalculatedPay(toCopy.calculatedPay);
             setTags(toCopy.tags);
         }
 
@@ -176,7 +181,7 @@ public class EditCommand extends Command {
          */
         public boolean isAnyFieldEdited() {
             return CollectionUtil.isAnyNonNull(name, phone, email, address, role, leave, hourlySalary, hoursWorked,
-                    tags);
+                    calculatedPay, tags);
         }
 
         public void setName(Name name) {
@@ -243,6 +248,14 @@ public class EditCommand extends Command {
             return Optional.ofNullable(hoursWorked);
         }
 
+        public void setCalculatedPay(CalculatedPay calculatedPay) {
+            this.calculatedPay = calculatedPay;
+        }
+
+        public Optional<CalculatedPay> getCalculatedPay() {
+            return Optional.ofNullable(calculatedPay);
+        }
+
         /**
          * Sets {@code tags} to this object's {@code tags}.
          * A defensive copy of {@code tags} is used internally.
@@ -283,6 +296,7 @@ public class EditCommand extends Command {
                     && getLeaves().equals(e.getLeaves())
                     && getSalary().equals(e.getSalary())
                     && getHoursWorked().equals(e.getHoursWorked())
+                    && getCalculatedPay().equals(e.getCalculatedPay())
                     && getTags().equals(e.getTags());
         }
     }

--- a/src/main/java/seedu/address/logic/commands/PayCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PayCommand.java
@@ -1,0 +1,86 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.CalculatedPay;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.HourlySalary;
+import seedu.address.model.person.HoursWorked;
+import seedu.address.model.person.Leave;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.Role;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Pays a person identified using it's displayed index from the address book.
+ */
+public class PayCommand extends Command {
+
+    public static final String COMMAND_WORD = "pay";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Pays the person identified by the index number used in the displayed person list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_PAY_PERSON_SUCCESS = "Successfully paid person: %1$s";
+
+    private final Index targetIndex;
+
+    public PayCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToPay = lastShownList.get(targetIndex.getZeroBased());
+        Person paidPerson = createPaidPerson(personToPay);
+        model.setPerson(personToPay, paidPerson);
+        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(String.format(MESSAGE_PAY_PERSON_SUCCESS, paidPerson));
+    }
+
+    private static Person createPaidPerson(Person personToPay) {
+        assert personToPay != null;
+
+        Name name = personToPay.getName();
+        Phone phone = personToPay.getPhone();
+        Email email = personToPay.getEmail();
+        Address address = personToPay.getAddress();
+        Role role = personToPay.getRole();
+        Leave leave = personToPay.getLeaves();
+        HourlySalary hourlySalary = personToPay.getSalary();
+        HoursWorked hours = personToPay.getHoursWorked();
+
+        // set calcPay to 0 to represent as paid
+        CalculatedPay calcPay = new CalculatedPay("0.0");
+
+        Set<Tag> tags = personToPay.getTags();
+
+        return new Person(name, phone, email, address, role, leave, hourlySalary, hours, calcPay, tags);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PayCommand // instanceof handles nulls
+                && targetIndex.equals(((PayCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/RemoveLeavesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveLeavesCommand.java
@@ -58,7 +58,7 @@ public class RemoveLeavesCommand extends Command {
             editedPerson = new Person(
                     personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(), personToEdit.getAddress(),
                     personToEdit.getRole(), personToEdit.getLeaves().removeLeaves(leave), personToEdit.getSalary(),
-                    personToEdit.getHoursWorked(), personToEdit.getTags());
+                    personToEdit.getHoursWorked(), personToEdit.getCalculatedPay(), personToEdit.getTags());
         } catch (IllegalArgumentException iae) {
             throw new CommandException(
                     String.format(Messages.MESSAGE_INVALID_REMOVELEAVES_INPUT, leave));

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.CalculatedPay;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.HourlySalary;
 import seedu.address.model.person.HoursWorked;
@@ -58,9 +59,11 @@ public class AddCommandParser implements Parser<AddCommand> {
         Leave leave = ParserUtil.parseLeaves(argMultimap.getValue(PREFIX_LEAVE).get());
         HourlySalary hourlySalary = ParserUtil.parseSalary(argMultimap.getValue(PREFIX_HOURLYSALARY).get());
         HoursWorked hoursWorked = ParserUtil.parseHoursWorked(argMultimap.getValue(PREFIX_HOURSWORKED).get());
+        CalculatedPay calculatedPay = new CalculatedPay("0");
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Person person = new Person(name, phone, email, address, role, leave, hourlySalary, hoursWorked, tagList);
+        Person person = new Person(name, phone, email, address, role, leave, hourlySalary, hoursWorked,
+                calculatedPay, tagList);
         return new AddCommand(person);
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.PayCommand;
 import seedu.address.logic.commands.RemoveLeavesCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -79,6 +80,9 @@ public class AddressBookParser {
 
         case CalculatePayCommand.COMMAND_WORD:
             return new CalculatePayCommandParser().parse(arguments);
+
+        case PayCommand.COMMAND_WORD:
+            return new PayCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/PayCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/PayCommandParser.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.PayCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class PayCommandParser implements Parser<PayCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the PayCommand
+     * and returns a PayCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public PayCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new PayCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PayCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/person/CalculatedPay.java
+++ b/src/main/java/seedu/address/model/person/CalculatedPay.java
@@ -1,0 +1,48 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+public class CalculatedPay {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Calculated pay should only contain non-negative values.";
+
+    public final double value;
+
+    /**
+     * Constructs a {@code CalculatedPay}.
+     *
+     * @param amount A valid calculated pay.
+     */
+    public CalculatedPay(String amount) {
+        requireNonNull(amount);
+        checkArgument(isValidCalculatedPay(amount), MESSAGE_CONSTRAINTS);
+        this.value = Double.parseDouble(amount);
+    }
+
+    /**
+     * Returns true if given numerical string is non-negative.
+     */
+    public static boolean isValidCalculatedPay(String test) {
+        requireNonNull(test);
+        try {
+            double amount = Double.parseDouble(test);
+            return amount >= 0;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%.2f", value);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof CalculatedPay // instanceof handles nulls
+                && value == ((CalculatedPay) other).value); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -30,13 +30,14 @@ public class Person {
     private final HourlySalary hourlySalary;
     private final HoursWorked hoursWorked;
     private final Overtime overtime;
+    private final CalculatedPay calculatedPay;
 
     /**
      * Constructs a {@code Person} object.
      * All fields except for overtime must be present and not null.
      */
     public Person(Name name, Phone phone, Email email, Address address, Role role, Leave leave,
-                  HourlySalary hourlySalary, HoursWorked hoursWorked, Set<Tag> tags) {
+                  HourlySalary hourlySalary, HoursWorked hoursWorked, CalculatedPay pay, Set<Tag> tags) {
         requireAllNonNull(name, phone, email, address, role, leave, hourlySalary, hoursWorked, tags);
         this.name = name;
         this.phone = phone;
@@ -47,6 +48,7 @@ public class Person {
         this.hourlySalary = hourlySalary;
         this.hoursWorked = hoursWorked;
         this.overtime = new Overtime("0");
+        this.calculatedPay = pay;
         this.tags.addAll(tags);
     }
 
@@ -55,7 +57,7 @@ public class Person {
      * All fields, including overtime, must be present and not null.
      */
     public Person(Name name, Phone phone, Email email, Address address, Role role, Leave leaves, HourlySalary salary,
-                  HoursWorked hoursWorked, Overtime overtime, Set<Tag> tags) {
+                  HoursWorked hoursWorked, Overtime overtime, CalculatedPay pay, Set<Tag> tags) {
         requireAllNonNull(name, phone, email, address, role, leaves, salary, hoursWorked, tags);
         this.name = name;
         this.phone = phone;
@@ -66,6 +68,7 @@ public class Person {
         this.hourlySalary = salary;
         this.hoursWorked = hoursWorked;
         this.overtime = overtime;
+        this.calculatedPay = pay;
         this.tags.addAll(tags);
     }
 
@@ -103,6 +106,10 @@ public class Person {
 
     public Overtime getOvertime() {
         return overtime;
+    }
+
+    public CalculatedPay getCalculatedPay() {
+        return calculatedPay;
     }
 
     /**
@@ -148,13 +155,15 @@ public class Person {
                 && otherPerson.getRole().equals(getRole())
                 && otherPerson.getLeaves().equals(getLeaves())
                 && otherPerson.getSalary().equals(getSalary())
+                && otherPerson.getOvertime().equals(getOvertime())
+                && otherPerson.getCalculatedPay().equals(getCalculatedPay())
                 && otherPerson.getTags().equals(getTags());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, role, leave, hourlySalary, hoursWorked, tags);
+        return Objects.hash(name, phone, email, address, role, leave, hourlySalary, hoursWorked, calculatedPay, tags);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.CalculatedPay;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.HourlySalary;
 import seedu.address.model.person.HoursWorked;
@@ -27,27 +28,27 @@ public class SampleDataUtil {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"), new Role("Admin Assistant"),
                 new Leave("5"), new HourlySalary("3000"), new HoursWorked("40"),
-                getTagSet("friends")),
+                new CalculatedPay("5000"), getTagSet("friends")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new Role("Senior Software Engineer"),
                 new Leave("14"), new HourlySalary("8500"), new HoursWorked("60"),
-                getTagSet("colleagues", "friends")),
+                new CalculatedPay("5000"), getTagSet("colleagues", "friends")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new Role("HR Manager"),
                 new Leave("9"), new HourlySalary("6000"), new HoursWorked("55"),
-                getTagSet("neighbours")),
+                new CalculatedPay("5000"), getTagSet("neighbours")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
                 new Role("Assistant Department Manager"), new Leave("10"), new HourlySalary("5000"),
-                new HoursWorked("55"), getTagSet("family")),
+                new HoursWorked("55"), new CalculatedPay("5000"), getTagSet("family")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"), new Role("Logistics Officer"),
                 new Leave("10"), new HourlySalary("4500"), new HoursWorked("52"),
-                getTagSet("classmates")),
+                    new CalculatedPay("5000"), getTagSet("classmates")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"), new Role("Chief Operations Officer"),
                 new Leave("20"), new HourlySalary("13000"), new HoursWorked("67"),
-                getTagSet("colleagues"))
+                new CalculatedPay("5000"), getTagSet("colleagues"))
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.CalculatedPay;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.HourlySalary;
 import seedu.address.model.person.HoursWorked;
@@ -38,6 +39,7 @@ class JsonAdaptedPerson {
     private final String salary;
     private final String hoursWorked;
     private final String overtime;
+    private final String calculatedPay;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
 
     /**
@@ -48,7 +50,8 @@ class JsonAdaptedPerson {
             @JsonProperty("email") String email, @JsonProperty("address") String address,
             @JsonProperty("role") String role, @JsonProperty("leaves") String leaves,
             @JsonProperty("salary") String salary, @JsonProperty("hoursWorked") String hoursWorked,
-            @JsonProperty("overtime") String overtime, @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+            @JsonProperty("overtime") String overtime, @JsonProperty("calculatedPay") String calculatedPay,
+            @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -58,6 +61,7 @@ class JsonAdaptedPerson {
         this.salary = salary;
         this.hoursWorked = hoursWorked;
         this.overtime = overtime;
+        this.calculatedPay = calculatedPay;
         if (tagged != null) {
             this.tagged.addAll(tagged);
         }
@@ -76,6 +80,7 @@ class JsonAdaptedPerson {
         salary = source.getSalary().toString();
         hoursWorked = source.getHoursWorked().toString();
         overtime = source.getOvertime().toString();
+        calculatedPay = source.getCalculatedPay().toString();
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -167,10 +172,19 @@ class JsonAdaptedPerson {
         }
         final Overtime modelOvertime = new Overtime(overtime);
 
+        if (calculatedPay == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    CalculatedPay.class.getSimpleName()));
+        }
+        if (!CalculatedPay.isValidCalculatedPay(calculatedPay)) {
+            throw new IllegalValueException(CalculatedPay.MESSAGE_CONSTRAINTS);
+        }
+        final CalculatedPay modelCalculatedPay = new CalculatedPay(calculatedPay);
+
         final Set<Tag> modelTags = new HashSet<>(personTags);
 
         return new Person(modelName, modelPhone, modelEmail, modelAddress, modelRole, modelLeave,
-                modelHourlySalary, modelHoursWorked, modelTags);
+                modelHourlySalary, modelHoursWorked, modelCalculatedPay, modelTags);
     }
 
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -49,7 +49,7 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label hoursWorked;
     @FXML
-    private VBox overdueSalary;
+    private VBox calculatedSalary;
     @FXML
     private FlowPane tags;
 
@@ -68,13 +68,13 @@ public class PersonCard extends UiPart<Region> {
         leave.setText(String.format("Leaves Remaining: %s", person.getLeaves().toString()));
         hoursWorked.setText(String.format("Hours Worked: %s", person.getHoursWorked().toString()));
 
-        String salaryDue = person.getSalary().toString(); // To be replaced by calculated salary
+        String salaryDue = person.getCalculatedPay().toString(); // To be replaced by calculated salary
         if (!salaryDue.equals("0.00")) {
             Text overDueText = new Text(String.format("NOT PAID [%s]", salaryDue));
             overDueText.setFill(Color.WHITE);
             overDueText.setFont(Font.font("Open Sans Regular", 20));
-            overdueSalary.getChildren().add(overDueText);
-            overdueSalary.setStyle("-fx-background-color: #C41E3A;");
+            calculatedSalary.getChildren().add(overDueText);
+            calculatedSalary.setStyle("-fx-background-color: #C41E3A;");
         }
 
         person.getTags().stream()

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -38,7 +38,7 @@
         <Label fx:id="leave" styleClass="cell_small_label" text="\$leave" />
         <Label fx:id="hoursWorked" styleClass="cell_small_label" text="\$hoursWorked" />
       </VBox>
-      <VBox fx:id="overdueSalary" minHeight="13" maxWidth="40" />
+      <VBox fx:id="calculatedSalary" minHeight="13" maxWidth="40" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/java/seedu/address/logic/commands/PayCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/PayCommandTest.java
@@ -1,0 +1,101 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.CalculatedPay;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.HourlySalary;
+import seedu.address.model.person.HoursWorked;
+import seedu.address.model.person.Leave;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.Role;
+import seedu.address.model.tag.Tag;
+
+
+public class PayCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    private static Person createPaidPerson(Person personToPay) {
+        assert personToPay != null;
+
+        Name name = personToPay.getName();
+        Phone phone = personToPay.getPhone();
+        Email email = personToPay.getEmail();
+        Address address = personToPay.getAddress();
+        Role role = personToPay.getRole();
+        Leave leave = personToPay.getLeaves();
+        HourlySalary hourlySalary = personToPay.getSalary();
+        HoursWorked hours = personToPay.getHoursWorked();
+
+        // set calcPay to 0 to represent as paid
+        CalculatedPay calcPay = new CalculatedPay("0.0");
+
+        Set<Tag> tags = personToPay.getTags();
+
+        return new Person(name, phone, email, address, role, leave, hourlySalary, hours, calcPay, tags);
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Person personToPay = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        PayCommand payCommand = new PayCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(PayCommand.MESSAGE_PAY_PERSON_SUCCESS, personToPay);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Person paidPerson = createPaidPerson(personToPay);
+        expectedModel.setPerson(personToPay, paidPerson);
+
+        assertCommandSuccess(payCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        PayCommand payCommand = new PayCommand(outOfBoundIndex);
+
+        assertCommandFailure(payCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        PayCommand payFirstCommand = new PayCommand(INDEX_FIRST_PERSON);
+        PayCommand paySecondCommand = new PayCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertTrue(payFirstCommand.equals(payFirstCommand));
+
+        // same values -> returns true
+        PayCommand payFirstCommandCopy = new PayCommand(INDEX_FIRST_PERSON);
+        assertTrue(payFirstCommand.equals(payFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(payFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(payFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(payFirstCommand.equals(paySecondCommand));
+    }
+
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -33,6 +33,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_HOURLYSALARY_NEGATIVE = "-3000";
     private static final String INVALID_HOURSWORKED_CHAR = "A day";
     private static final String INVALID_HOURSWORKED_NEGATIVE = "-27";
+    private static final String INVALID_CALCULATEDPAY = "-1";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = BENSON.getName().toString();
@@ -44,6 +45,7 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_HOURLYSALARY = BENSON.getSalary().toString();
     private static final String VALID_HOURSWORKED = BENSON.getHoursWorked().toString();
     private static final String VALID_OVERTIME = BENSON.getOvertime().toString();
+    private static final String VALID_CALCULATEDPAY = BENSON.getCalculatedPay().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -58,7 +60,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_ROLE,
-                VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME, VALID_TAGS);
+                VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME, VALID_CALCULATEDPAY, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -66,7 +68,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ROLE, VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME, VALID_TAGS);
+                VALID_ROLE, VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME,
+                VALID_CALCULATEDPAY, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -75,7 +78,8 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_ROLE, VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME, VALID_TAGS);
+                        VALID_ROLE, VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME,
+                        VALID_CALCULATEDPAY, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -83,7 +87,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_ROLE,
-                VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME, VALID_TAGS);
+                VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME, VALID_CALCULATEDPAY, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -92,7 +96,8 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_ROLE,
-                        VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME, VALID_TAGS);
+                        VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME,
+                        VALID_CALCULATEDPAY, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -100,7 +105,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_ROLE,
-                VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME, VALID_TAGS);
+                VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME, VALID_CALCULATEDPAY, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -109,7 +114,8 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_ROLE,
-                        VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME, VALID_TAGS);
+                        VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME,
+                        VALID_CALCULATEDPAY, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -117,7 +123,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_ROLE,
-                VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME, VALID_TAGS);
+                VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME, VALID_CALCULATEDPAY, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -125,7 +131,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullRole_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, null,
-                VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME, VALID_TAGS);
+                VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME, VALID_CALCULATEDPAY, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Role.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -133,7 +139,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidRole_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                INVALID_ROLE, VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME,
+                INVALID_ROLE, VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME, VALID_CALCULATEDPAY,
                 VALID_TAGS);
         String expectedMessage = Role.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -142,7 +148,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullLeaves_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ROLE, null, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME,
+                VALID_ROLE, null, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME, VALID_CALCULATEDPAY,
                 VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Leave.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -152,7 +158,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_negativeLeaves_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                 VALID_ROLE, INVALID_LEAVES_NEGATIVE, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME,
-                VALID_TAGS);
+                VALID_CALCULATEDPAY, VALID_TAGS);
         String expectedMessage = Leave.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -161,7 +167,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_characterInLeaves_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                 VALID_ROLE, INVALID_LEAVES_CHAR, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME,
-                VALID_TAGS);
+                VALID_CALCULATEDPAY, VALID_TAGS);
         String expectedMessage = Leave.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -169,7 +175,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullSalary_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ROLE, VALID_LEAVES, null, VALID_HOURSWORKED, VALID_OVERTIME, VALID_TAGS);
+                VALID_ROLE, VALID_LEAVES, null, VALID_HOURSWORKED, VALID_OVERTIME,
+                VALID_CALCULATEDPAY, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, HourlySalary.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -177,7 +184,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_negativeSalary_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ROLE, VALID_LEAVES, INVALID_HOURLYSALARY_NEGATIVE, VALID_HOURSWORKED, VALID_OVERTIME, VALID_TAGS);
+                VALID_ROLE, VALID_LEAVES, INVALID_HOURLYSALARY_NEGATIVE, VALID_HOURSWORKED, VALID_OVERTIME,
+                VALID_CALCULATEDPAY, VALID_TAGS);
         String expectedMessage = HourlySalary.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -185,7 +193,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_characterInSalary_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ROLE, VALID_LEAVES, INVALID_HOURLYSALARY_CHAR, VALID_HOURSWORKED, VALID_OVERTIME, VALID_TAGS);
+                VALID_ROLE, VALID_LEAVES, INVALID_HOURLYSALARY_CHAR, VALID_HOURSWORKED, VALID_OVERTIME,
+                VALID_CALCULATEDPAY, VALID_TAGS);
         String expectedMessage = HourlySalary.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -193,7 +202,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullHoursWorked_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ROLE, VALID_LEAVES, VALID_HOURLYSALARY, null, VALID_OVERTIME, VALID_TAGS);
+                VALID_ROLE, VALID_LEAVES, VALID_HOURLYSALARY, null, VALID_OVERTIME,
+                VALID_CALCULATEDPAY, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, HoursWorked.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -201,7 +211,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_negativeHoursWorked_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ROLE, VALID_LEAVES, VALID_HOURLYSALARY, INVALID_HOURSWORKED_NEGATIVE, VALID_OVERTIME, VALID_TAGS);
+                VALID_ROLE, VALID_LEAVES, VALID_HOURLYSALARY, INVALID_HOURSWORKED_NEGATIVE, VALID_OVERTIME,
+                VALID_CALCULATEDPAY, VALID_TAGS);
         String expectedMessage = HoursWorked.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -209,7 +220,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_characterInHoursWorked_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ROLE, VALID_LEAVES, VALID_HOURLYSALARY, INVALID_HOURSWORKED_CHAR, VALID_OVERTIME, VALID_TAGS);
+                VALID_ROLE, VALID_LEAVES, VALID_HOURLYSALARY, INVALID_HOURSWORKED_CHAR, VALID_OVERTIME,
+                VALID_CALCULATEDPAY, VALID_TAGS);
         String expectedMessage = HoursWorked.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -220,7 +232,9 @@ public class JsonAdaptedPersonTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_ROLE,
-                        VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME, invalidTags);
+                        VALID_LEAVES, VALID_HOURLYSALARY, VALID_HOURSWORKED, VALID_OVERTIME,
+                        VALID_CALCULATEDPAY, invalidTags);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
+
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import seedu.address.model.person.Address;
+import seedu.address.model.person.CalculatedPay;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.HourlySalary;
 import seedu.address.model.person.HoursWorked;
@@ -29,6 +30,7 @@ public class PersonBuilder {
     public static final String DEFAULT_SALARY = "5000";
     public static final String DEFAULT_HOURSWORKED = "70";
 
+
     private Name name;
     private Phone phone;
     private Email email;
@@ -37,6 +39,10 @@ public class PersonBuilder {
     private Leave leave;
     private HourlySalary hourlySalary;
     private HoursWorked hoursWorked;
+
+    // When person initialized, always set pay to 0.
+    private CalculatedPay calculatedPay = new CalculatedPay("0.00");
+
     private Set<Tag> tags;
 
     /**
@@ -142,7 +148,7 @@ public class PersonBuilder {
     }
 
     public Person build() {
-        return new Person(name, phone, email, address, role, leave, hourlySalary, hoursWorked, tags);
+        return new Person(name, phone, email, address, role, leave, hourlySalary, hoursWorked, calculatedPay, tags);
     }
 
 }


### PR DESCRIPTION
Redone implementation, added `CalculatedPay` class and added the new `calculatedPay` attribute to the `Person` class.
Edit Person constructor to take in calculatedPay attribute as well.
The relevant fields in other classes and files have been amended account for the new attribute and constructor.

PayCommand implemented by replacing `personToPay` with `paidPerson`, where `paidPerson` 's `calculatedPay` is 0.

Added a few tests for PayCommand, should add more in future.
Resolves #49 and #50 