### PR TITLE
Fix bugs in PayCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/PayCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PayCommand.java
@@ -114,7 +114,8 @@ public class PayCommand extends Command {
 
     private CommandResult executePayAll(Model model) throws CommandException {
         assert nonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        // Create a deep copy of the filtered list
+        List<Person> lastShownList = new ArrayList<>(model.getFilteredPersonList());
         List<Person> personsSkippedList = new ArrayList<>();
         Person firstPersonToBePaid = null;
 
@@ -135,6 +136,9 @@ public class PayCommand extends Command {
             if (!personToPay.isPaid()) {
                 Person paidPerson = createPaidPerson(personToPay);
                 model.setPerson(personToPay, paidPerson);
+                if (personToPay.isSamePerson(firstPersonToBePaid)) {
+                    firstPersonToBePaid = paidPerson;
+                }
             } else {
                 personsSkippedList.add(personToPay);
             }


### PR DESCRIPTION
Update `executePayAll` to use a deep copy of the filtered list to prevent errors related to modifying the list mid-iteration (Resolves #117)
Update `executePayAll` to set the info panel to the updated paid person object, instead of the old unpaid person object (Resolves #112)

Commit https://github.com/AY2122S1-CS2103T-F11-3/tp/pull/116/commits/2d495c9f7686b7ecf6814c6afb5a5fbf83106c84  resolves #115 