### PR TITLE
Fix payroll bugs from Pe-d

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -378,7 +378,9 @@ It can be viewed through the `viewOvertimePayRate` command or changed through th
 Format: `startPayroll`
 * Calculates the payroll of **all employees regardless of current viewing list** based on the formula above.
 * After that, marks all employees as awaiting payment of the calculated amount.
-  This will produce red labels under each employee data stating 'NOT PAID' and the amount they are owed.
+<br>This will produce red labels under each employee data stating 'NOT PAID' and the amount they are owed.
+* The number of hours worked and overtime hours worked for the employee will be reset to 0 as well 
+  so that hours counting towards the next payroll can continue to be added.
 * Finally, display the list of all employees.
 * This command is typically followed up by `pay` commands to mark employees as paid, 
   after their salaries are given in real life.
@@ -403,7 +405,6 @@ Marks the specified employee, or all employees in the current list, as paid.
 Format 1: `pay INDEX` - for paying a specific employee
 * Simulates the paying of an employee by clearing the salary owed to the employee by setting it back to 0. This clears the red
   `NOT PAID` label under the employee's data.
-* The number of hours worked and overtime hours of the employee will be reset to 0 as well.
 * This command is typically used after the `startPayroll` command, which sets the pay owed to the respective employees.
   The pay command can then be followed after to clear the pay owed.
 * The index refers to the index number shown in the displayed employee list.
@@ -427,8 +428,6 @@ Displays the current overtime pay rate set in the application.
 Format: `viewOvertimePayRate`
 
 * Displays the current overtime pay rate in the feedback panel.
-  
-![viewing overtime pay rate](images/viewOvertimePayRate.png)
 
 #### Set a new Overtime Pay Rate : `setOvertimePayRate`
 
@@ -441,11 +440,9 @@ Format: `setOvertimePayRate OVERTIMEPAYRATE`
 
 Examples:
 * `setOvertimePayRate 2.0` sets the new overtime pay rate to be 2x.
-  ![successfully changed overtime pay rate](images/setOvertimePayRate_success.png)
   
 
 * `setOvertimePayRate 0.5` would be invalid as `OVERTIMEPAYRATE` must be at least 1. An error message would be shown.
-  ![error: overtime pay rate too low](images/setOvertimePayRate_error.png)
 
 ### Data-related Features
 

--- a/src/main/java/seedu/address/logic/commands/PayCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PayCommand.java
@@ -174,10 +174,8 @@ public class PayCommand extends Command {
         LeaveBalance leaveBalance = personToPay.getLeaveBalance();
         LeavesTaken leavesTaken = personToPay.getLeavesTaken();
         HourlySalary hourlySalary = personToPay.getSalary();
-
-        // reset hours worked and overtime back to zero after being paid
-        HoursWorked newHours = new HoursWorked("0");
-        Overtime newOvertime = new Overtime("0");
+        HoursWorked hoursWorked = personToPay.getHoursWorked();
+        Overtime overtime = personToPay.getOvertime();
 
         // set calcPay to 0 to represent as paid
         CalculatedPay newCalcPay = new CalculatedPay("0.0");
@@ -185,7 +183,7 @@ public class PayCommand extends Command {
         Set<Tag> tags = personToPay.getTags();
 
         return new Person(name, phone, email, address, role, leaveBalance, leavesTaken, hourlySalary,
-                newHours, newOvertime, newCalcPay, tags);
+                hoursWorked, overtime, newCalcPay, tags);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/StartPayrollCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StartPayrollCommand.java
@@ -26,7 +26,8 @@ import seedu.address.model.tag.Tag;
 /**
  * Calculates the payroll for all employees in the address book according to the
  * how much work has been done at the current time.
- * After that, marks all employees as awaiting payment of the calculated amount.
+ * After that, marks all employees as awaiting payment of the calculated amount
+ * and resets their hours worked and overtime to zero.
  */
 public class StartPayrollCommand extends Command {
 
@@ -59,6 +60,7 @@ public class StartPayrollCommand extends Command {
 
         // Get the current set pay rate for overtime
         OvertimePayRate overtimePayRate = model.getOvertimePayRate();
+        assert overtimePayRate != null;
 
         // If there are no unpaid employees, proceed with calculating payroll
         for (Person personToCalculatePay: personList) {
@@ -69,7 +71,9 @@ public class StartPayrollCommand extends Command {
 
             // Set the employee to be owed the calculated pay
             Person personWithCalculatedPay = createPersonWithCalculatedPay(personToCalculatePay, calculatedPay);
-            model.setPerson(personToCalculatePay, personWithCalculatedPay);
+            // and reset their hours worked and overtime to zero
+            Person personWithPayrollDone = createPersonWithZeroHoursWorkedAndOvertime(personWithCalculatedPay);
+            model.setPerson(personToCalculatePay, personWithPayrollDone);
         }
 
         model.setViewingPerson(personList.get(0));
@@ -80,29 +84,66 @@ public class StartPayrollCommand extends Command {
 
     private CalculatedPay calculatePay(HourlySalary salary, HoursWorked hoursWorked, Overtime overtime,
                                        OvertimePayRate overtimePayRate) {
+        assert salary != null;
+        assert hoursWorked != null;
+        assert overtime != null;
+        assert overtimePayRate != null;
+
         double normalPay = salary.value * hoursWorked.value;
         double overtimePay = overtimePayRate.value * salary.value * overtime.value;
+
+        // Check that the pay should not be negative
+        assert normalPay >= 0;
+        assert overtimePay >= 0;
+
         // Ensure that the total pay is rounded to 2 decimal places.
         String totalRoundedPay = String.format("%.2f", normalPay + overtimePay);
 
         return new CalculatedPay(totalRoundedPay);
     }
 
-    private Person createPersonWithCalculatedPay(Person personWithCalculatedPay, CalculatedPay newCalculatedPay) {
-        Name name = personWithCalculatedPay.getName();
-        Phone phone = personWithCalculatedPay.getPhone();
-        Email email = personWithCalculatedPay.getEmail();
-        Address address = personWithCalculatedPay.getAddress();
-        Role role = personWithCalculatedPay.getRole();
-        LeaveBalance leaves = personWithCalculatedPay.getLeaveBalance();
-        LeavesTaken leavesTaken = personWithCalculatedPay.getLeavesTaken();
-        HourlySalary hourlySalary = personWithCalculatedPay.getSalary();
-        HoursWorked hours = personWithCalculatedPay.getHoursWorked();
-        Overtime overtime = personWithCalculatedPay.getOvertime();
-        Set<Tag> tags = personWithCalculatedPay.getTags();
+    private Person createPersonWithCalculatedPay(Person person, CalculatedPay newCalculatedPay) {
+        assert person != null;
+        assert newCalculatedPay != null;
+
+        Name name = person.getName();
+        Phone phone = person.getPhone();
+        Email email = person.getEmail();
+        Address address = person.getAddress();
+        Role role = person.getRole();
+        LeaveBalance leaves = person.getLeaveBalance();
+        LeavesTaken leavesTaken = person.getLeavesTaken();
+        HourlySalary hourlySalary = person.getSalary();
+        HoursWorked hoursWorked = person.getHoursWorked();
+        Overtime overtime = person.getOvertime();
+        // New calculatedPay taken from input parameter
+        Set<Tag> tags = person.getTags();
 
         return new Person(name, phone, email, address, role, leaves, leavesTaken, hourlySalary,
-                hours, overtime, newCalculatedPay, tags);
+                hoursWorked, overtime, newCalculatedPay, tags);
+    }
+
+    private Person createPersonWithZeroHoursWorkedAndOvertime(Person person) {
+        assert person != null;
+
+        Name name = person.getName();
+        Phone phone = person.getPhone();
+        Email email = person.getEmail();
+        Address address = person.getAddress();
+        Role role = person.getRole();
+        LeaveBalance leaves = person.getLeaveBalance();
+        LeavesTaken leavesTaken = person.getLeavesTaken();
+        HourlySalary hourlySalary = person.getSalary();
+
+        // reset hours worked and overtime to zero
+        HoursWorked zeroHours = new HoursWorked("0");
+        Overtime zeroOvertime = new Overtime("0");
+
+        CalculatedPay calculatedPay = person.getCalculatedPay();
+        Set<Tag> tags = person.getTags();
+
+        return new Person(name, phone, email, address, role, leaves, leavesTaken, hourlySalary,
+                zeroHours, zeroOvertime, calculatedPay, tags);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/StartPayrollCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StartPayrollCommand.java
@@ -22,7 +22,6 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.person.Role;
 import seedu.address.model.tag.Tag;
 
-
 /**
  * Calculates the payroll for all employees in the address book according to the
  * how much work has been done at the current time.

--- a/src/main/java/seedu/address/logic/commands/StartPayrollCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StartPayrollCommand.java
@@ -14,6 +14,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.HourlySalary;
 import seedu.address.model.person.HoursWorked;
 import seedu.address.model.person.LeaveBalance;
+import seedu.address.model.person.LeavesTaken;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Overtime;
 import seedu.address.model.person.Person;
@@ -94,11 +95,14 @@ public class StartPayrollCommand extends Command {
         Address address = personWithCalculatedPay.getAddress();
         Role role = personWithCalculatedPay.getRole();
         LeaveBalance leaves = personWithCalculatedPay.getLeaveBalance();
-        HourlySalary salary = personWithCalculatedPay.getSalary();
+        LeavesTaken leavesTaken = personWithCalculatedPay.getLeavesTaken();
+        HourlySalary hourlySalary = personWithCalculatedPay.getSalary();
         HoursWorked hours = personWithCalculatedPay.getHoursWorked();
+        Overtime overtime = personWithCalculatedPay.getOvertime();
         Set<Tag> tags = personWithCalculatedPay.getTags();
 
-        return new Person(name, phone, email, address, role, leaves, salary, hours, newCalculatedPay, tags);
+        return new Person(name, phone, email, address, role, leaves, leavesTaken, hourlySalary,
+                hours, overtime, newCalculatedPay, tags);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/InfoPanel.java
+++ b/src/main/java/seedu/address/ui/InfoPanel.java
@@ -21,7 +21,7 @@ public class InfoPanel extends UiPart<Region> {
     private static final String ROLE_ICON = "👤 ";
     private static final String SALARY_ICON = "\uD83D\uDCB2 ";
     private static final String HOURSWORKED_ICON = "\uD83D\uDD51 ";
-    private static final String OVERTIME_ICON = " ↷  ";
+    private static final String OVERTIME_ICON = "↷  ";
     private static final String LEAVES_ICON = "\uD83C\uDF42 ";
     private static final String DATES_ICON = "\uD83D\uDDD3 ";
 
@@ -78,12 +78,14 @@ public class InfoPanel extends UiPart<Region> {
         leaveBalance.setText(String.format(LEAVES_ICON + "Leaves Remaining: %s", person.getLeaveBalance().toString()));
         leaveDates.setText(DATES_ICON + person.getLeavesTaken().toDisplayString());
         salary.setText(String.format(SALARY_ICON + "Hourly salary: $%s" + " per hour", person.getSalary().toString()));
-        hoursWorked.setText(String.format(HOURSWORKED_ICON + "Hours Worked: %s", person.getHoursWorked().toString()));
-        overtime.setText(String.format(OVERTIME_ICON + "Overtime Hours Worked: %s", person.getOvertime().toString()));
+        hoursWorked.setText(String.format(HOURSWORKED_ICON + "Current Hours Worked: %s",
+                person.getHoursWorked().toString()));
+        overtime.setText(String.format(OVERTIME_ICON + "Current Overtime Hours Worked: %s",
+                person.getOvertime().toString()));
 
         double salaryDue = person.getCalculatedPay().value; // To be replaced by calculated salary
         if (salaryDue > 0) {
-            salaryOwed.setText(String.format("%s left unpaid!!", salaryDue));
+            salaryOwed.setText(String.format("%s left unpaid from last payroll!!", salaryDue));
         } else {
             salaryOwed.setText("");
         }

--- a/src/main/java/seedu/address/ui/InfoPanel.java
+++ b/src/main/java/seedu/address/ui/InfoPanel.java
@@ -81,8 +81,8 @@ public class InfoPanel extends UiPart<Region> {
         hoursWorked.setText(String.format(HOURSWORKED_ICON + "Hours Worked: %s", person.getHoursWorked().toString()));
         overtime.setText(String.format(OVERTIME_ICON + "Overtime Hours Worked: %s", person.getOvertime().toString()));
 
-        String salaryDue = person.getCalculatedPay().toString(); // To be replaced by calculated salary
-        if (!salaryDue.equals("0.00")) {
+        double salaryDue = person.getCalculatedPay().value; // To be replaced by calculated salary
+        if (salaryDue > 0) {
             salaryOwed.setText(String.format("%s left unpaid!!", salaryDue));
         } else {
             salaryOwed.setText("");

--- a/src/test/java/seedu/address/logic/commands/PayCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/PayCommandTest.java
@@ -36,18 +36,25 @@ public class PayCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
-    private Person createPersonWithCalculatedPay(Person personWithCalculatedPay, CalculatedPay newCalculatedPay) {
-        Name name = personWithCalculatedPay.getName();
-        Phone phone = personWithCalculatedPay.getPhone();
-        Email email = personWithCalculatedPay.getEmail();
-        Address address = personWithCalculatedPay.getAddress();
-        Role role = personWithCalculatedPay.getRole();
-        LeaveBalance leaves = personWithCalculatedPay.getLeaveBalance();
-        HourlySalary salary = personWithCalculatedPay.getSalary();
-        HoursWorked hours = personWithCalculatedPay.getHoursWorked();
-        Set<Tag> tags = personWithCalculatedPay.getTags();
+    private Person createPersonWithCalculatedPay(Person person, CalculatedPay newCalculatedPay) {
+        assert person != null;
+        assert newCalculatedPay != null;
 
-        return new Person(name, phone, email, address, role, leaves, salary, hours, newCalculatedPay, tags);
+        Name name = person.getName();
+        Phone phone = person.getPhone();
+        Email email = person.getEmail();
+        Address address = person.getAddress();
+        Role role = person.getRole();
+        LeaveBalance leaves = person.getLeaveBalance();
+        LeavesTaken leavesTaken = person.getLeavesTaken();
+        HourlySalary hourlySalary = person.getSalary();
+        HoursWorked hoursWorked = person.getHoursWorked();
+        Overtime overtime = person.getOvertime();
+        // New calculatedPay taken from input parameter
+        Set<Tag> tags = person.getTags();
+
+        return new Person(name, phone, email, address, role, leaves, leavesTaken, hourlySalary,
+                hoursWorked, overtime, newCalculatedPay, tags);
     }
 
     private static Person createPaidPerson(Person personToPay) {
@@ -61,10 +68,8 @@ public class PayCommandTest {
         LeaveBalance leaveBalance = personToPay.getLeaveBalance();
         LeavesTaken leavesTaken = personToPay.getLeavesTaken();
         HourlySalary hourlySalary = personToPay.getSalary();
-
-        // reset hours worked and overtime back to zero after being paid
-        HoursWorked newHours = new HoursWorked("0");
-        Overtime newOvertime = new Overtime("0");
+        HoursWorked hoursWorked = personToPay.getHoursWorked();
+        Overtime overtime = personToPay.getOvertime();
 
         // set calcPay to 0 to represent as paid
         CalculatedPay newCalcPay = new CalculatedPay("0.0");
@@ -72,7 +77,7 @@ public class PayCommandTest {
         Set<Tag> tags = personToPay.getTags();
 
         return new Person(name, phone, email, address, role, leaveBalance, leavesTaken, hourlySalary,
-                newHours, newOvertime, newCalcPay, tags);
+                hoursWorked, overtime, newCalcPay, tags);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/StartPayrollCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/StartPayrollCommandTest.java
@@ -47,21 +47,48 @@ public class StartPayrollCommandTest {
         return new CalculatedPay(totalRoundedPay);
     }
 
-    private Person createPersonWithCalculatedPay(Person personWithCalculatedPay, CalculatedPay newCalculatedPay) {
-        Name name = personWithCalculatedPay.getName();
-        Phone phone = personWithCalculatedPay.getPhone();
-        Email email = personWithCalculatedPay.getEmail();
-        Address address = personWithCalculatedPay.getAddress();
-        Role role = personWithCalculatedPay.getRole();
-        LeaveBalance leaves = personWithCalculatedPay.getLeaveBalance();
-        LeavesTaken leavesTaken = personWithCalculatedPay.getLeavesTaken();
-        HourlySalary hourlySalary = personWithCalculatedPay.getSalary();
-        HoursWorked hours = personWithCalculatedPay.getHoursWorked();
-        Overtime overtime = personWithCalculatedPay.getOvertime();
-        Set<Tag> tags = personWithCalculatedPay.getTags();
+    private Person createPersonWithCalculatedPay(Person person, CalculatedPay newCalculatedPay) {
+        assert person != null;
+        assert newCalculatedPay != null;
+
+        Name name = person.getName();
+        Phone phone = person.getPhone();
+        Email email = person.getEmail();
+        Address address = person.getAddress();
+        Role role = person.getRole();
+        LeaveBalance leaves = person.getLeaveBalance();
+        LeavesTaken leavesTaken = person.getLeavesTaken();
+        HourlySalary hourlySalary = person.getSalary();
+        HoursWorked hoursWorked = person.getHoursWorked();
+        Overtime overtime = person.getOvertime();
+        // new calculatedPay taken from input parameter
+        Set<Tag> tags = person.getTags();
 
         return new Person(name, phone, email, address, role, leaves, leavesTaken, hourlySalary,
-                hours, overtime, newCalculatedPay, tags);
+                hoursWorked, overtime, newCalculatedPay, tags);
+    }
+
+    private Person createPersonWithZeroHoursWorkedAndOvertime(Person person) {
+        assert person != null;
+
+        Name name = person.getName();
+        Phone phone = person.getPhone();
+        Email email = person.getEmail();
+        Address address = person.getAddress();
+        Role role = person.getRole();
+        LeaveBalance leaves = person.getLeaveBalance();
+        LeavesTaken leavesTaken = person.getLeavesTaken();
+        HourlySalary hourlySalary = person.getSalary();
+
+        // reset hours worked and overtime to zero
+        HoursWorked zeroHours = new HoursWorked("0");
+        Overtime zeroOvertime = new Overtime("0");
+
+        CalculatedPay calculatedPay = person.getCalculatedPay();
+        Set<Tag> tags = person.getTags();
+
+        return new Person(name, phone, email, address, role, leaves, leavesTaken, hourlySalary,
+                zeroHours, zeroOvertime, calculatedPay, tags);
     }
 
     @Test
@@ -79,7 +106,8 @@ public class StartPayrollCommandTest {
             CalculatedPay calculatedPay = calculatePay(salary, hoursWorked, overtime, overtimePayRate);
 
             Person personWithCalculatedPay = createPersonWithCalculatedPay(personToCalculatePay, calculatedPay);
-            expectedModel.setPerson(personToCalculatePay, personWithCalculatedPay);
+            Person personWithPayrollDone = createPersonWithZeroHoursWorkedAndOvertime(personWithCalculatedPay);
+            expectedModel.setPerson(personToCalculatePay, personWithPayrollDone);
         }
 
         String expectedMessage =
@@ -106,7 +134,8 @@ public class StartPayrollCommandTest {
             CalculatedPay calculatedPay = calculatePay(salary, hoursWorked, overtime, overtimePayRate);
 
             Person personWithCalculatedPay = createPersonWithCalculatedPay(personToCalculatePay, calculatedPay);
-            expectedModel.setPerson(personToCalculatePay, personWithCalculatedPay);
+            Person personWithPayrollDone = createPersonWithZeroHoursWorkedAndOvertime(personWithCalculatedPay);
+            expectedModel.setPerson(personToCalculatePay, personWithPayrollDone);
         }
 
         String expectedMessage =

--- a/src/test/java/seedu/address/logic/commands/StartPayrollCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/StartPayrollCommandTest.java
@@ -21,6 +21,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.HourlySalary;
 import seedu.address.model.person.HoursWorked;
 import seedu.address.model.person.LeaveBalance;
+import seedu.address.model.person.LeavesTaken;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Overtime;
 import seedu.address.model.person.Person;
@@ -53,11 +54,14 @@ public class StartPayrollCommandTest {
         Address address = personWithCalculatedPay.getAddress();
         Role role = personWithCalculatedPay.getRole();
         LeaveBalance leaves = personWithCalculatedPay.getLeaveBalance();
-        HourlySalary salary = personWithCalculatedPay.getSalary();
+        LeavesTaken leavesTaken = personWithCalculatedPay.getLeavesTaken();
+        HourlySalary hourlySalary = personWithCalculatedPay.getSalary();
         HoursWorked hours = personWithCalculatedPay.getHoursWorked();
+        Overtime overtime = personWithCalculatedPay.getOvertime();
         Set<Tag> tags = personWithCalculatedPay.getTags();
 
-        return new Person(name, phone, email, address, role, leaves, salary, hours, newCalculatedPay, tags);
+        return new Person(name, phone, email, address, role, leaves, leavesTaken, hourlySalary,
+                hours, overtime, newCalculatedPay, tags);
     }
 
     @Test


### PR DESCRIPTION
Fix bug where leaves taken was reset when startPayroll command was executed (resolves #147).
Fix bug where "-0 left unpaid" would be shown for an employee (resolves #156).
Update startPayroll and pay commands to fix loophole where new hours worked and overtime could still be added but is not counted towards payroll and is erased when paid (resolves #159, resolves #164, resolves #183). Refer to commit 8a0be2a31a2467e82286e8fbaffa50a3decd362e for more information.
Update UG regarding the changes in startPayroll and pay commands.