### PR TITLE
Find command bugs v1.4

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -11,7 +11,7 @@ import seedu.address.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "HeRon employee list has been cleared!";
 
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -85,9 +85,9 @@ public class FindCommandParser implements Parser<FindCommand> {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
-        if (!preamble.isBlank() && !preamble.equals(UNPAID_PREDICATE_KEYWORD) ) {  // preamble that is not 'unpaid'
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        if (!preamble.isBlank() && !preamble.equals(UNPAID_PREDICATE_KEYWORD)) { // preamble that is not 'unpaid'
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
         ArrayList<Predicate<Person>> filters = new ArrayList<>();

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -85,11 +85,9 @@ public class FindCommandParser implements Parser<FindCommand> {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
-        if (!preamble.isBlank()) { // a preamble exists
-            if (!preamble.equals(UNPAID_PREDICATE_KEYWORD)) {
+        if (!preamble.isBlank() && !preamble.equals(UNPAID_PREDICATE_KEYWORD) ) {  // preamble that is not 'unpaid'
                 throw new ParseException(
                         String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-            }
         }
 
         ArrayList<Predicate<Person>> filters = new ArrayList<>();

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -63,6 +63,8 @@ public class FindCommandParser implements Parser<FindCommand> {
         LESS_THAN_EQUAL, LESS_THAN, EQUAL, MORE_THAN, MORE_THAN_EQUAL
     }
 
+    private final static String UNPAID_PREDICATE_KEYWORD = "unpaid";
+
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
@@ -77,16 +79,23 @@ public class FindCommandParser implements Parser<FindCommand> {
                         PREFIX_LEAVE, PREFIX_DATE, PREFIX_HOURLYSALARY, PREFIX_HOURSWORKED, PREFIX_TAG,
                         PREFIX_OVERTIME);
 
-        String preamble = argMultimap.getPreamble();
+        String preamble = argMultimap.getPreamble().trim();
         if (trimmedArgs.isEmpty() && preamble.isEmpty()) {
+            // no arguments provided to the command
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+        if (!preamble.isBlank()) { // a preamble exists
+            if (!preamble.equals(UNPAID_PREDICATE_KEYWORD)) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            }
         }
 
         ArrayList<Predicate<Person>> filters = new ArrayList<>();
 
         // Check if prefix exists and add the relevant predicate into the list of filters
-        if (preamble.contains("unpaid")) {
+        if (preamble.equals(UNPAID_PREDICATE_KEYWORD)) {
             filters.add(new PersonIsPaidPredicate());
         }
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -63,7 +63,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         LESS_THAN_EQUAL, LESS_THAN, EQUAL, MORE_THAN, MORE_THAN_EQUAL
     }
 
-    private final static String UNPAID_PREDICATE_KEYWORD = "unpaid";
+    private static final String UNPAID_PREDICATE_KEYWORD = "unpaid";
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -46,6 +46,11 @@ public class FindCommandParserTest {
     }
 
     @Test
+    public void parse_invalidPreamble_throwsParseException() {
+        assertParseFailure(parser, " asdfpw", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
     public void parse_noComparisonOperatorSalaryArg_throwsParseException() {
         assertParseFailure(parser, " " + PREFIX_HOURLYSALARY + "5",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
@@ -89,7 +94,7 @@ public class FindCommandParserTest {
             throw new IllegalArgumentException("Invalid userInput.", pe);
         }
     }
-    
+
     @Test
     public void parse_validNameArgs_returnsFindCommand() {
         FindCommand expectedFindCommand =

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -25,10 +25,12 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.predicates.AddressContainsKeywordsPredicate;
 import seedu.address.model.person.predicates.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.PersonIsPaidPredicate;
 import seedu.address.model.person.predicates.PhoneNumberMatchesPredicate;
 import seedu.address.model.person.predicates.RoleContainsKeywordsPredicate;
 import seedu.address.model.person.predicates.SalaryIsEqualPredicate;
 import seedu.address.model.person.predicates.TagContainsKeywordsPredicate;
+import seedu.address.testutil.PersonBuilder;
 
 public class FindCommandParserTest {
 
@@ -73,6 +75,21 @@ public class FindCommandParserTest {
      * Current workaround: test both predicates of FindCommand with given
      * inputs and see if both predicates return the same result for the inputs.
      */
+    @Test
+    public void parse_validPreamble_returnsFindCommand() {
+        FindCommand expectedFindCommand =
+                new FindCommand(new PersonIsPaidPredicate());
+        try {
+            FindCommand parsedFindCommand = parser.parse("unpaid");
+            Person unpaidPerson = new PersonBuilder().withCalculatedPay("100").build();
+            Person paidPerson = new PersonBuilder().build();
+            assertPredicatesAreEqual(expectedFindCommand, parsedFindCommand, unpaidPerson);
+            assertPredicatesAreEqual(expectedFindCommand, parsedFindCommand, paidPerson);
+        } catch (ParseException pe) {
+            throw new IllegalArgumentException("Invalid userInput.", pe);
+        }
+    }
+    
     @Test
     public void parse_validNameArgs_returnsFindCommand() {
         FindCommand expectedFindCommand =

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -153,6 +153,14 @@ public class PersonBuilder {
     }
 
     /**
+     * Sets the {@code CalculatedPay} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withCalculatedPay(String pay) {
+        this.calculatedPay = new CalculatedPay(pay);
+        return this;
+    }
+
+    /**
      * Sets the {@code Salary} of the {@code Person} that we are building.
      */
     public PersonBuilder withHourlySalary(String salary) {


### PR DESCRIPTION
Fix situation where random words are allowed as a preamble to the find command. Now only accepts `find unpaid`. (Resolves #131 , resolves #145, resolves #149, resolves #173)
Also change clear command's success message to mention HeRon. (Resolves #166)