### PR TITLE
Fix display content when employee list empty

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -2,13 +2,13 @@ package seedu.address.logic;
 
 import java.nio.file.Path;
 
-import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.ObservablePerson;
 import seedu.address.model.person.Person;
 
 /**
@@ -35,7 +35,7 @@ public interface Logic {
     ObservableList<Person> getFilteredPersonList();
 
     /** Return person that is to be viewed in the InfoPanel */
-    ObservableObjectValue<Person> getViewingPerson();
+    ObservablePerson getViewingPerson();
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.logging.Logger;
 
-import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
@@ -15,6 +14,7 @@ import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.ObservablePerson;
 import seedu.address.model.person.Person;
 import seedu.address.storage.Storage;
 
@@ -66,7 +66,7 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ObservableObjectValue<Person> getViewingPerson() {
+    public ObservablePerson getViewingPerson() {
         return model.getViewingPerson();
     }
 

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -13,11 +13,11 @@ public class ClearCommand extends Command {
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
 
-
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
+        model.setViewingPerson(null);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -45,7 +45,7 @@ public class DeleteCommand extends Command {
         if (model.isFilteredPersonListEmpty()) {
             // View blank
             model.setViewingPerson(null);
-        } else if (personToDelete.equals(model.getViewingPerson().get())) {
+        } else if (personToDelete.isSamePerson(model.getViewingPerson().get())) {
             // Employee no longer exists, switch to viewing first employee
             Person firstPerson = model.getFilteredPersonList().get(0);
             model.setViewingPerson(firstPerson);

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -45,8 +45,10 @@ public class DeleteCommand extends Command {
         if (model.isFilteredPersonListEmpty()) {
             // View blank
             model.setViewingPerson(null);
-        } else {
-            // Show first employee
+        }
+
+        if (personToDelete.equals(model.getViewingPerson().get())) {
+            // Employee no longer exists, switch to viewing first employee
             Person firstPerson = model.getFilteredPersonList().get(0);
             model.setViewingPerson(firstPerson);
         }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -51,7 +51,7 @@ public class DeleteCommand extends Command {
             model.setViewingPerson(firstPerson);
         }
 
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete.getName()));
+        return new CommandResult(String.format(MESSAGE_DELETE_EMPLOYEE_SUCCESS, personToDelete.getName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -45,7 +45,7 @@ public class DeleteCommand extends Command {
         if (model.isFilteredPersonListEmpty()) {
             // View blank
             model.setViewingPerson(null);
-        } else if (personToDelete.isSamePerson(model.getViewingPerson().get())) {
+        } else if (personToDelete.isSamePerson(model.getViewingPerson().getPerson())) {
             // Employee no longer exists, switch to viewing first employee
             Person firstPerson = model.getFilteredPersonList().get(0);
             model.setViewingPerson(firstPerson);

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -45,9 +45,7 @@ public class DeleteCommand extends Command {
         if (model.isFilteredPersonListEmpty()) {
             // View blank
             model.setViewingPerson(null);
-        }
-
-        if (personToDelete.equals(model.getViewingPerson().get())) {
+        } else if (personToDelete.equals(model.getViewingPerson().get())) {
             // Employee no longer exists, switch to viewing first employee
             Person firstPerson = model.getFilteredPersonList().get(0);
             model.setViewingPerson(firstPerson);

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -41,6 +41,16 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
+
+        if (model.isFilteredPersonListEmpty()) {
+            // View blank
+            model.setViewingPerson(null);
+        } else {
+            // Show first employee
+            Person firstPerson = model.getFilteredPersonList().get(0);
+            model.setViewingPerson(firstPerson);
+        }
+
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }
 

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -85,9 +85,6 @@ public class ImportCommand extends Command {
             throw new CommandException(e.getMessage());
         }
 
-        List<Person> importedList = model.getFilteredPersonList();
-        model.setViewingPerson(importedList.get(0));
-
         return result;
     }
 

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -84,6 +84,10 @@ public class ImportCommand extends Command {
             // Should not happen since "1" is a valid index, and import file must have at least 1 entry.
             throw new CommandException(e.getMessage());
         }
+
+        List<Person> importedList = model.getFilteredPersonList();
+        model.setViewingPerson(importedList.get(0));
+
         return result;
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,7 +1,6 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -3,9 +3,9 @@ package seedu.address.model;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 
-import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.person.ObservablePerson;
 import seedu.address.model.person.Person;
 
 /**
@@ -99,7 +99,7 @@ public interface Model {
     /**
      * Returns the person that is to be viewed in the InfoPanel
      */
-    ObservableObjectValue<Person> getViewingPerson();
+    ObservablePerson getViewingPerson();
 
     /**
      * Sets the person to be viewed in the InfoPanel

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -96,8 +96,19 @@ public interface Model {
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
 
+    /**
+     * Returns the person that is to be viewed in the InfoPanel
+     */
     ObservableObjectValue<Person> getViewingPerson();
 
+    /**
+     * Sets the person to be viewed in the InfoPanel
+     */
     void setViewingPerson(Person p);
+
+    /**
+     * Returns true if the employee list is empty, otherwise false.
+     */
+    boolean isFilteredPersonListEmpty();
 
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -42,7 +43,7 @@ public class ModelManager implements Model {
         ObservableList<Person> personList = this.addressBook.getPersonList();
         if (personList.isEmpty()) {
             // Set view to blank
-            viewingPerson = new ObservablePerson(null);
+            viewingPerson = new ObservablePerson();
         } else {
             // Default to view first person in employee list
             viewingPerson = new ObservablePerson(this.addressBook.getPersonList().get(0));
@@ -165,7 +166,11 @@ public class ModelManager implements Model {
 
     @Override
     public void setViewingPerson(Person p) {
-        viewingPerson.setPerson(p);
+        Optional<Person> toView = Optional.ofNullable(p);
+        toView.ifPresentOrElse(
+                viewingPerson::setPerson,
+                viewingPerson::setEmptyPerson
+        );
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -7,12 +7,11 @@ import java.nio.file.Path;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
-import javafx.beans.property.ReadOnlyObjectWrapper;
-import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.person.ObservablePerson;
 import seedu.address.model.person.Person;
 
 /**
@@ -25,7 +24,7 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
 
-    private final ReadOnlyObjectWrapper<Person> viewingPerson;
+    private final ObservablePerson viewingPerson;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -43,10 +42,10 @@ public class ModelManager implements Model {
         ObservableList<Person> personList = this.addressBook.getPersonList();
         if (personList.isEmpty()) {
             // Set view to blank
-            viewingPerson = new ReadOnlyObjectWrapper<Person>(null);
+            viewingPerson = new ObservablePerson(null);
         } else {
             // Default to view first person in employee list
-            viewingPerson = new ReadOnlyObjectWrapper<Person>(this.addressBook.getPersonList().get(0));
+            viewingPerson = new ObservablePerson(this.addressBook.getPersonList().get(0));
         }
     }
 
@@ -160,13 +159,13 @@ public class ModelManager implements Model {
 
     //=========== Viewing Person Details =====================================================================
     @Override
-    public ObservableObjectValue<Person> getViewingPerson() {
+    public ObservablePerson getViewingPerson() {
         return viewingPerson;
     }
 
     @Override
     public void setViewingPerson(Person p) {
-        viewingPerson.set(p);
+        viewingPerson.setPerson(p);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
-import java.util.HashSet;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -14,17 +13,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.CalculatedPay;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.HourlySalary;
-import seedu.address.model.person.HoursWorked;
-import seedu.address.model.person.LeaveBalance;
-import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
-import seedu.address.model.person.Role;
-import seedu.address.model.tag.Tag;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -53,18 +42,12 @@ public class ModelManager implements Model {
 
         ObservableList<Person> personList = this.addressBook.getPersonList();
         if (personList.isEmpty()) {
-            HashSet<Tag> egTags = new HashSet<>();
-            egTags.add(new Tag("example"));
-            Person examplePerson = new Person(new Name("Example person"), new Phone("62353535"),
-                    new Email("example@empl.com"), new Address("Example Street, Blk 404"),
-                    new Role("Exemplar"), new LeaveBalance("69"),
-                    new HourlySalary("666"), new HoursWorked("420"),
-                    new CalculatedPay("0"), egTags);
-            viewingPerson = new ReadOnlyObjectWrapper<Person>(examplePerson);
+            // Set view to blank
+            viewingPerson = new ReadOnlyObjectWrapper<Person>(null);
         } else {
+            // Default to view first person in employee list
             viewingPerson = new ReadOnlyObjectWrapper<Person>(this.addressBook.getPersonList().get(0));
         }
-
     }
 
     public ModelManager() {
@@ -170,6 +153,11 @@ public class ModelManager implements Model {
         filteredPersons.setPredicate(predicate);
     }
 
+    @Override
+    public boolean isFilteredPersonListEmpty() {
+        return filteredPersons.isEmpty();
+    }
+
     //=========== Viewing Person Details =====================================================================
     @Override
     public ObservableObjectValue<Person> getViewingPerson() {
@@ -178,9 +166,7 @@ public class ModelManager implements Model {
 
     @Override
     public void setViewingPerson(Person p) {
-        requireNonNull(p);
         viewingPerson.set(p);
-        System.out.println("Setting viewing person:\n" + p.toString());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/ObservablePerson.java
+++ b/src/main/java/seedu/address/model/person/ObservablePerson.java
@@ -1,0 +1,51 @@
+package seedu.address.model.person;
+
+import java.util.ArrayList;
+
+import seedu.address.ui.UiObserver;
+
+
+/**
+ * Observable class for Person to use Observer pattern to update InfoPanel.
+ */
+public class ObservablePerson {
+    private Person personToView;
+    private ArrayList<UiObserver> uiObserverList = new ArrayList<>();
+
+    /**
+     * Initialises the ObservablePerson object with the person to be viewed.
+     */
+    public ObservablePerson(Person person) {
+        personToView = person;
+    }
+
+    /**
+     * Sets the new person to be viewed in the ObservablePerson object,
+     * and updates the respective Ui components that are observing it.
+     */
+    public void setPerson(Person person) {
+        personToView = person;
+        updateUi();
+    }
+
+    public Person get() {
+        return personToView;
+    }
+
+    /**
+     * Adds any {@code UiObserver} to the list of observers to be updated when
+     * {@code personToView} is updated through {@code setPerson}.
+     */
+    public void addUiObserver(UiObserver observer) {
+        uiObserverList.add(observer);
+    }
+
+    /**
+     * Updates the {@code UiObservers} in the observer list with the current person to view.
+     */
+    private void updateUi() {
+        for (UiObserver obs : uiObserverList) {
+            obs.update(personToView);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/person/ObservablePerson.java
+++ b/src/main/java/seedu/address/model/person/ObservablePerson.java
@@ -1,5 +1,7 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.ArrayList;
 
 import seedu.address.ui.UiObserver;
@@ -9,39 +11,62 @@ import seedu.address.ui.UiObserver;
  * Observable class for Person to use Observer pattern to update InfoPanel.
  */
 public class ObservablePerson {
+
     private Person personToView;
-    private ArrayList<UiObserver> uiObserverList = new ArrayList<>();
+    private final ArrayList<UiObserver> uiObserverList = new ArrayList<>();
 
     /**
      * Initialises the ObservablePerson object with the person to be viewed.
+     * @param person Person to be viewed
      */
     public ObservablePerson(Person person) {
         personToView = person;
     }
 
     /**
+     * Initialises the ObservablePerson object with null as person to view,
+     * representing that no person is to be viewed.
+     */
+    public ObservablePerson() {
+        personToView = null;
+    }
+
+    /**
      * Sets the new person to be viewed in the ObservablePerson object,
      * and updates the respective Ui components that are observing it.
+     * @param person New person to be viewed
      */
     public void setPerson(Person person) {
+        requireNonNull(person);
+
         personToView = person;
         updateUi();
     }
 
-    public Person get() {
+    /**
+     * Sets person to be viewed as null, representing that no person is to be viewed,
+     * and updates the respective Ui components that are observing it.
+     */
+    public void setEmptyPerson() {
+        personToView = null;
+        updateUi();
+    }
+
+    public Person getPerson() {
         return personToView;
     }
 
     /**
      * Adds any {@code UiObserver} to the list of observers to be updated when
      * {@code personToView} is updated through {@code setPerson}.
+     * @param observer Observer to be updated upon change of viewing person
      */
     public void addUiObserver(UiObserver observer) {
         uiObserverList.add(observer);
     }
 
     /**
-     * Updates the {@code UiObservers} in the observer list with the current person to view.
+     * Updates all the {@code UiObserver} in the observer list with the current person to view.
      */
     private void updateUi() {
         for (UiObserver obs : uiObserverList) {

--- a/src/main/java/seedu/address/ui/InfoPanel.java
+++ b/src/main/java/seedu/address/ui/InfoPanel.java
@@ -65,7 +65,7 @@ public class InfoPanel extends UiPart<Region> implements UiObserver {
     private Label textOverlay;
 
     /**
-     * Creates a {@code InfoPanel} with the given {@code Person}.
+     * Creates an {@code InfoPanel} that displays information based on the given {@code ObservablePerson}.
      * @param p
      */
     public InfoPanel(ObservablePerson p) {
@@ -74,7 +74,9 @@ public class InfoPanel extends UiPart<Region> implements UiObserver {
         textOverlay.setText(LIST_EMPTY_MSG);
         textOverlay.setTextAlignment(TextAlignment.CENTER);
 
-        updateInfoPanel(p.get());
+        updateInfoPanel(p.getPerson());
+
+        // Add InfoPanel to the ObserverList of the ObservablePerson
         p.addUiObserver(this);
     }
 

--- a/src/main/java/seedu/address/ui/InfoPanel.java
+++ b/src/main/java/seedu/address/ui/InfoPanel.java
@@ -5,8 +5,10 @@ import java.util.Comparator;
 import javafx.beans.value.ObservableObjectValue;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.Region;
+import javafx.scene.text.TextAlignment;
 import seedu.address.model.person.Person;
 
 /**
@@ -15,6 +17,7 @@ import seedu.address.model.person.Person;
 public class InfoPanel extends UiPart<Region> {
     private static final String FXML = "InfoPanel.fxml";
 
+    // Icons
     private static final String EMAIL_ICON = "@ ";
     private static final String PHONE_ICON = "☎ ";
     private static final String ADDRESS_ICON = "\uD83C\uDFE0 ";
@@ -24,7 +27,14 @@ public class InfoPanel extends UiPart<Region> {
     private static final String OVERTIME_ICON = " ↷  ";
     private static final String LEAVES_ICON = "\uD83C\uDF42 ";
     private static final String DATES_ICON = "\uD83D\uDDD3 ";
+    private static final String LEFT_ARROW_ICON = "\uD83E\uDC14 ";
 
+    private static final String LIST_EMPTY_MSG = LEFT_ARROW_ICON + LEFT_ARROW_ICON + LEFT_ARROW_ICON + '\n'
+            + "Your employee list is empty!! \n"
+            + "Start adding employees with 'add n/NAME e/EMAIL ...'";
+
+    @FXML
+    private ScrollPane main;
     @FXML
     private Label name;
     @FXML
@@ -51,6 +61,8 @@ public class InfoPanel extends UiPart<Region> {
     private Label salaryOwed;
     @FXML
     private FlowPane tags;
+    @FXML
+    private Label textOverlay;
 
     /**
      * Creates a {@code InfoPanel} with the given {@code Person}.
@@ -58,6 +70,10 @@ public class InfoPanel extends UiPart<Region> {
      */
     public InfoPanel(ObservableObjectValue<Person> p) {
         super(FXML);
+
+        textOverlay.setText(LIST_EMPTY_MSG);
+        textOverlay.setTextAlignment(TextAlignment.CENTER);
+
         updateInfoPanel(p.get());
         p.addListener((x, y, z) -> {
             updateInfoPanel(z);
@@ -66,34 +82,59 @@ public class InfoPanel extends UiPart<Region> {
     }
 
     /**
+     * Removes the overlay on top of the InfoPanel
+     */
+    private void unlock() {
+        main.setVisible(true);
+        main.setManaged(true);
+    }
+
+    /**
+     * Applies the overlay on top of the InfoPanel
+     */
+    private void lock() {
+        main.setVisible(false);
+        main.setManaged(false);
+    }
+
+    /**
      * Fills in the data of the person into the Info Panel fields.
      * @param person Person to get the update info from
      */
     public void updateInfoPanel(Person person) {
-        name.setText(person.getName().fullName);
-        phone.setText(PHONE_ICON + person.getPhone().value);
-        address.setText(ADDRESS_ICON + person.getAddress().value);
-        email.setText(EMAIL_ICON + person.getEmail().value);
-        role.setText(ROLE_ICON + person.getRole().value);
-        leaveBalance.setText(String.format(LEAVES_ICON + "Leaves Remaining: %s", person.getLeaveBalance().toString()));
-        leaveDates.setText(DATES_ICON + person.getLeavesTaken().toDisplayString());
-        salary.setText(String.format(SALARY_ICON + "Hourly salary: $%s" + " per hour", person.getSalary().toString()));
-        hoursWorked.setText(String.format(HOURSWORKED_ICON + "Hours Worked: %s", person.getHoursWorked().toString()));
-        overtime.setText(String.format(OVERTIME_ICON + "Overtime Hours Worked: %s", person.getOvertime().toString()));
+        if (person != null) {
+            unlock();
 
-        String salaryDue = person.getCalculatedPay().toString(); // To be replaced by calculated salary
-        if (!salaryDue.equals("0.00")) {
-            salaryOwed.setText(String.format("%s left unpaid!!", salaryDue));
+            name.setText(person.getName().fullName);
+            phone.setText(PHONE_ICON + person.getPhone().value);
+            address.setText(ADDRESS_ICON + person.getAddress().value);
+            email.setText(EMAIL_ICON + person.getEmail().value);
+            role.setText(ROLE_ICON + person.getRole().value);
+            leaveDates.setText(DATES_ICON + person.getLeavesTaken().toDisplayString());
+            leaveBalance.setText(
+                    String.format(LEAVES_ICON + "Leaves Remaining: %s", person.getLeaveBalance().toString()));
+            salary.setText(
+                    String.format(SALARY_ICON + "Hourly salary: $%s" + " per hour", person.getSalary().toString()));
+            hoursWorked.setText(
+                    String.format(HOURSWORKED_ICON + "Hours Worked: %s", person.getHoursWorked().toString()));
+            overtime.setText(
+                    String.format(OVERTIME_ICON + "Overtime Hours Worked: %s", person.getOvertime().toString()));
+
+
+            String salaryDue = person.getCalculatedPay().toString(); // To be replaced by calculated salary
+            if (!salaryDue.equals("0.00")) {
+                salaryOwed.setText(String.format("%s left unpaid!!", salaryDue));
+            } else {
+                salaryOwed.setText("");
+            }
+
+            tags.getChildren().clear();
+            person.getTags().stream()
+                    .sorted(Comparator.comparing(tag -> tag.tagName))
+                    .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
         } else {
-            salaryOwed.setText("");
+            lock();
         }
-
-        tags.getChildren().clear();
-        person.getTags().stream()
-                .sorted(Comparator.comparing(tag -> tag.tagName))
-                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
-
-        System.out.println("InfoPanel to display:\n" + person.toString());
     }
 
 }

--- a/src/main/java/seedu/address/ui/InfoPanel.java
+++ b/src/main/java/seedu/address/ui/InfoPanel.java
@@ -82,7 +82,9 @@ public class InfoPanel extends UiPart<Region> {
     }
 
     /**
-     * Removes the overlay on top of the InfoPanel
+     * Removes the overlay on top of the InfoPanel.
+     * Overlay prevents user from viewing the contents of the InfoPanel,
+     * and displays {@code LIST_EMPTY_MSG} on top of it to notify user to start importing or adding employees.
      */
     private void unlock() {
         main.setVisible(true);
@@ -90,7 +92,9 @@ public class InfoPanel extends UiPart<Region> {
     }
 
     /**
-     * Applies the overlay on top of the InfoPanel
+     * Applies the overlay on top of the InfoPanel.
+     * Overlay prevents user from viewing the contents of the InfoPanel,
+     * and displays {@code LIST_EMPTY_MSG} on top of it to notify user to start importing or adding employees.
      */
     private void lock() {
         main.setVisible(false);

--- a/src/main/java/seedu/address/ui/InfoPanel.java
+++ b/src/main/java/seedu/address/ui/InfoPanel.java
@@ -2,19 +2,19 @@ package seedu.address.ui;
 
 import java.util.Comparator;
 
-import javafx.beans.value.ObservableObjectValue;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.Region;
 import javafx.scene.text.TextAlignment;
+import seedu.address.model.person.ObservablePerson;
 import seedu.address.model.person.Person;
 
 /**
  * Display panel which shows the information and details of a Person.
  */
-public class InfoPanel extends UiPart<Region> {
+public class InfoPanel extends UiPart<Region> implements UiObserver {
     private static final String FXML = "InfoPanel.fxml";
 
     // Icons
@@ -68,17 +68,14 @@ public class InfoPanel extends UiPart<Region> {
      * Creates a {@code InfoPanel} with the given {@code Person}.
      * @param p
      */
-    public InfoPanel(ObservableObjectValue<Person> p) {
+    public InfoPanel(ObservablePerson p) {
         super(FXML);
 
         textOverlay.setText(LIST_EMPTY_MSG);
         textOverlay.setTextAlignment(TextAlignment.CENTER);
 
         updateInfoPanel(p.get());
-        p.addListener((x, y, z) -> {
-            updateInfoPanel(z);
-            System.out.println(y);
-        });
+        p.addUiObserver(this);
     }
 
     /**
@@ -141,4 +138,11 @@ public class InfoPanel extends UiPart<Region> {
         }
     }
 
+    /**
+     * Updates the InfoPanel display content with person provided.
+     */
+    @Override
+    public void update(Person person) {
+        updateInfoPanel(person);
+    }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -180,7 +180,6 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
-            infoPanel.updateInfoPanel(logic.getViewingPerson().get());
 
             if (commandResult.isShowHelp()) {
                 handleHelp();

--- a/src/main/java/seedu/address/ui/UiObserver.java
+++ b/src/main/java/seedu/address/ui/UiObserver.java
@@ -1,0 +1,13 @@
+package seedu.address.ui;
+
+import seedu.address.model.person.Person;
+
+/**
+ * Dedicated observer class for Ui components
+ */
+public interface UiObserver {
+
+    /** Updates the observer with {@code person} to view */
+    void update(Person person);
+
+}

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -21,6 +21,14 @@
     -fx-opacity: 0.9;
 }
 
+.label-base {
+    -fx-font-size: 11pt;
+    -fx-font-family: "Open Sans Semibold";
+    -fx-text-fill: -fx-baseDark;
+    -fx-opacity: 1;
+}
+
+
 .label-bright {
     -fx-font-size: 11pt;
     -fx-font-family: "Open Sans Semibold";

--- a/src/main/resources/view/InfoPanel.fxml
+++ b/src/main/resources/view/InfoPanel.fxml
@@ -7,9 +7,19 @@
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.layout.HBox?>
 
+<?import javafx.scene.layout.BorderPane?>
 <StackPane fx:id="placeHolder" xmlns="http://javafx.com/javafx/8" styleClass="stack-pane"
            xmlns:fx="http://javafx.com/fxml/1" maxWidth="Infinity">
-    <ScrollPane styleClass="scroll-pane-info" maxHeight="Infinity" maxWidth="Infinity" >
+    <ScrollPane styleClass="scroll-pane-info" maxHeight="Infinity" maxWidth="Infinity" />
+
+    <BorderPane>
+        <center>
+            <Label fx:id="textOverlay" text="The Employee List is Empty!!" styleClass="label-base"
+                   BorderPane.alignment="CENTER" />
+        </center>
+    </BorderPane>
+
+    <ScrollPane fx:id="main" styleClass="scroll-pane-info" maxHeight="Infinity" maxWidth="Infinity" >
         <HBox styleClass="scroll-pane-info">
             <VBox minWidth="5" />
             <VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,7 @@
 
 <?import javafx.scene.layout.HBox?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-         title="HeRon" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+         title="HeRon" minWidth="950" minHeight="600" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -5,5 +5,5 @@
 
 <StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/8"
     xmlns:fx="http://javafx.com/fxml/1">
-  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
+  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" wrapText="true"/>
 </StackPane>

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -13,7 +13,6 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -22,6 +21,7 @@ import seedu.address.model.Model;
 import seedu.address.model.OvertimePayRate;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.person.ObservablePerson;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
 
@@ -161,7 +161,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public ObservableObjectValue<Person> getViewingPerson() {
+        public ObservablePerson getViewingPerson() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -170,9 +170,13 @@ public class AddCommandTest {
             /*
             Although the class is meant to have all methods failing,
             addCommand on execute is supposed to call function to update the InfoPanel.
-            Unsure what to do with this.
             */
             System.out.println("Setting viewing person...");
+        }
+
+        @Override
+        public boolean isFilteredPersonListEmpty() {
+            throw new AssertionError("This method should not be called.");
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -14,7 +14,6 @@ import java.util.function.Predicate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javafx.beans.value.ObservableObjectValue;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -22,6 +21,7 @@ import seedu.address.model.Model;
 import seedu.address.model.OvertimePayRate;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.person.ObservablePerson;
 import seedu.address.model.person.Person;
 
 public class ImportCommandTest {
@@ -186,7 +186,7 @@ public class ImportCommandTest {
         }
 
         @Override
-        public ObservableObjectValue<Person> getViewingPerson() {
+        public ObservablePerson getViewingPerson() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -195,6 +195,11 @@ public class ImportCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+        @Override
+        public boolean isFilteredPersonListEmpty() {
+            throw new AssertionError("This method should not be called.");
+        }
+
     }
 
     /**


### PR DESCRIPTION
Added overlay display on top of InfoPanel when employee list becomes empty due to `clear` and `delete` commands.

Also edited `delete` command to switch to viewing the first person in the employee list if list is not empty.

Resolves #157 and resolves #175