### PR TITLE
PE-D Bug fixes

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -10,8 +10,14 @@ public class Messages {
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_INVALID_INTEGER_INPUT =
-            "Please input a valid positive integer when adding/removing leaves or hours worked! \n%1$s";
-    public static final String MESSAGE_INVALID_REMOVE_INPUT = "Employee has less than %1$s %2$s!";
+            "Please input a valid positive integer when adding/removing hours worked! \n%1$s";
+    public static final String MESSAGE_INVALID_LEAVES_INPUT =
+            "Please input a positive integer value between 1 and 365 (both inclusive) "
+                    + "when adding/removing leaves! \n%1$s";
+    public static final String MESSAGE_INVALID_REMOVE_INPUT =
+            "Employee has less than %1$s %2$s! (Currently has %3$s %4$s)";
+    public static final String MESSAGE_INVALID_ADD_INPUT =
+            "Employee cannot have more than %1$s %2$s! (Can add at most %3$s %4$s)";
     public static final String MESSAGE_INSUFFICIENT_LEAVES = "Employee %1$s does not have any more leaves! \n";
     public static final String MESSAGE_INVALID_DATE_FORMAT = "Invalid date format! (Correct format: YYYY-MM-DD) \n%1$s";
     public static final String MESSAGE_INVALID_FINDDATE_FORMAT =

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -1,5 +1,9 @@
 package seedu.address.commons.core;
 
+import seedu.address.model.person.HoursWorked;
+import seedu.address.model.person.LeaveBalance;
+import seedu.address.model.person.Overtime;
+
 /**
  * Container for user visible messages.
  */
@@ -9,11 +13,18 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
-    public static final String MESSAGE_INVALID_INTEGER_INPUT =
-            "Please input a valid positive integer when adding/removing hours worked! \n%1$s";
     public static final String MESSAGE_INVALID_LEAVES_INPUT =
-            "Please input a positive integer value between 1 and 365 (both inclusive) "
-                    + "when adding/removing leaves! \n%1$s";
+            "Please input a positive integer value between " + (LeaveBalance.MIN_LEAVES + 1)
+                    + " and " + LeaveBalance.MAX_LEAVES
+                    + " (both inclusive) when adding/removing leaves! \n%1$s";
+    public static final String MESSAGE_INVALID_HOURS_WORKED_INPUT =
+            "Please input a positive integer value between " + (HoursWorked.MIN_HOURS_WORKED + 1)
+                    + " and " + HoursWorked.MAX_HOURS_WORKED
+                    + " (both inclusive) when adding/removing hours worked! \n%1$s";
+    public static final String MESSAGE_INVALID_OVERTIME_INPUT =
+            "Please input a positive integer value between " + (Overtime.MIN_OVERTIME + 1)
+                    + " and " + Overtime.MAX_OVERTIME
+                    + " (both inclusive) when adding/removing overtime! \n%1$s";
     public static final String MESSAGE_INVALID_REMOVE_INPUT =
             "Employee has less than %1$s %2$s! (Currently has %3$s %4$s)";
     public static final String MESSAGE_INVALID_ADD_INPUT =

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -60,7 +60,27 @@ public class StringUtil {
 
         try {
             int value = Integer.parseInt(s);
-            return value > 0 && !s.startsWith("+"); // "+1" is successfully parsed by Integer#parseInt(String)
+            // "+1" is successfully parsed by Integer#parseInt(String)
+            return value > 0 && !s.startsWith("+") && !s.contains("-");
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns true if {@code s} represents a non-negative integer
+     * e.g. 0, 1, 2, 3, ..., {@code Integer.MAX_VALUE} <br>
+     * Will return false for any other non-null string input
+     * e.g. empty string, "-1", "0", "+1", and " 2 " (untrimmed), "3 0" (contains whitespace), "1 a" (contains letters)
+     * @throws NullPointerException if {@code s} is null.
+     */
+    public static boolean isNonNegativeInteger(String s) {
+        requireNonNull(s);
+
+        try {
+            int value = Integer.parseInt(s);
+            // "+1" is successfully parsed by Integer#parseInt(String)
+            return value >= 0 && !s.startsWith("+") && !s.contains("-");
         } catch (NumberFormatException nfe) {
             return false;
         }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -33,6 +33,7 @@ public class AddCommand extends Command {
             + PREFIX_LEAVE + "LEAVES "
             + PREFIX_HOURLYSALARY + "SALARY "
             + PREFIX_HOURSWORKED + "HOURS WORKED "
+            + PREFIX_OVERTIME + "OVERTIME "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -23,7 +23,7 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an employee to HeRon. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
@@ -32,7 +32,7 @@ public class AddCommand extends Command {
             + PREFIX_ROLE + "ROLE "
             + PREFIX_LEAVE + "LEAVES "
             + PREFIX_HOURLYSALARY + "SALARY "
-            + PREFIX_HOURSWORKED + "HOURS WORKED "
+            + PREFIX_HOURSWORKED + "HOURS_WORKED "
             + PREFIX_OVERTIME + "OVERTIME "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
@@ -48,8 +48,8 @@ public class AddCommand extends Command {
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
 
-    public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_SUCCESS = "New employee added: %1$s";
+    public static final String MESSAGE_DUPLICATE_EMPLOYEE = "This employee already exists in HeRon";
 
     private final Person toAdd;
 
@@ -66,7 +66,7 @@ public class AddCommand extends Command {
         requireNonNull(model);
 
         if (model.hasPerson(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            throw new CommandException(MESSAGE_DUPLICATE_EMPLOYEE);
         }
 
         model.addPerson(toAdd);

--- a/src/main/java/seedu/address/logic/commands/AddHoursWorkedCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddHoursWorkedCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.commons.util.StringUtil.isNonZeroUnsignedInteger;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HOURSWORKED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_OVERTIME;
 
@@ -57,17 +58,57 @@ public class AddHoursWorkedCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
-        Person editedPerson = new Person(
-                personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(), personToEdit.getAddress(),
-                personToEdit.getRole(), personToEdit.getLeaveBalance(), personToEdit.getLeavesTaken(),
-                personToEdit.getSalary(), personToEdit.getHoursWorked().addHoursWorked(hoursWorked),
-                personToEdit.getOvertime().addOvertime(overtime),
-                personToEdit.getCalculatedPay(), personToEdit.getTags());
+        Person editedPerson = getUpdatedPerson(personToEdit);
 
         model.setPerson(personToEdit, editedPerson);
         model.setViewingPerson(editedPerson);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, editedPerson.toString()));
+    }
+
+    /**
+     * Returns a {@code Person} object with updated hours worked and overtime hours worked.
+     *
+     * @param personToEdit The person object that is to be edited.
+     * @return An updated Person object.
+     * @throws CommandException if the added amount of hours worked/overtime causes the Person's
+     * hours worked/overtime to exceed the maximum allowed amount
+     */
+    private Person getUpdatedPerson(Person personToEdit) throws CommandException {
+        HoursWorked newHoursWorked = personToEdit.getHoursWorked();
+        try {
+            // Check if hours worked input is a positive integer before calling addHoursWorked
+            if (isNonZeroUnsignedInteger(hoursWorked.toString())) {
+                newHoursWorked = personToEdit.getHoursWorked().addHoursWorked(hoursWorked);
+            }
+        } catch (IllegalArgumentException iae) {
+            String hoursWorkedCapacityString =
+                    personToEdit.getHoursWorked().getRemainingHoursWorkedCapacity().toString();
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_ADD_INPUT,
+                    HoursWorked.MAX_HOURS_WORKED,
+                    "hours worked", hoursWorkedCapacityString,
+                    hoursWorkedCapacityString.equals("1") ? "hour worked" : "hours worked"));
+        }
+
+        Overtime newOvertime = personToEdit.getOvertime();
+        try {
+            // Check if overtime input is a positive integer before calling addOvertime
+            if (isNonZeroUnsignedInteger(overtime.toString())) {
+                newOvertime = personToEdit.getOvertime().addOvertime(overtime);
+            }
+        } catch (IllegalArgumentException iae) {
+            String overtimeCapacityString =
+                    personToEdit.getOvertime().getRemainingOvertimeCapacity().toString();
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_ADD_INPUT,
+                    Overtime.MAX_OVERTIME,
+                    "overtime hours worked", overtimeCapacityString,
+                    overtimeCapacityString.equals("1") ? "overtime hour worked" : "overtime hours worked"));
+        }
+
+        return new Person(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
+                personToEdit.getAddress(), personToEdit.getRole(), personToEdit.getLeaveBalance(),
+                personToEdit.getLeavesTaken(), personToEdit.getSalary(), newHoursWorked, newOvertime,
+                personToEdit.getCalculatedPay(), personToEdit.getTags());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddHoursWorkedCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddHoursWorkedCommand.java
@@ -23,13 +23,15 @@ public class AddHoursWorkedCommand extends Command {
     public static final String COMMAND_WORD = "addHoursWorked";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds hours worked OR overtime to the employee identified "
-            + "by the index number used in the last person listing. \n"
+            + "by the index number used in the employee listing. \n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_HOURSWORKED + "NO_OF_HOURS_WORKED] (must be a positive integer) "
             + "[" + PREFIX_OVERTIME + "NO_OF_HOURS_WORKED_OVERTIME] (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1 " + PREFIX_HOURSWORKED + "2";
     public static final String MESSAGE_SUCCESS =
-            "Successfully added hours worked to person: %1$s";
+            "Successfully added hours worked to employee: %1$s "
+                    + "(Employee now has %2$s hour%3$s worked and "
+                    + "%4$s overtime hour%5$s worked)";
 
     private final Index index;
     private final HoursWorked hoursWorked;
@@ -63,7 +65,12 @@ public class AddHoursWorkedCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         model.setViewingPerson(editedPerson);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, editedPerson.toString()));
+        return new CommandResult(String.format(MESSAGE_SUCCESS,
+                        editedPerson.getName().toString(),
+                        editedPerson.getHoursWorked().toString(),
+                        editedPerson.getHoursWorked().toString().equals("1") ? "" : "s",
+                        editedPerson.getOvertime().toString(),
+                        editedPerson.getOvertime().toString().equals("1") ? "" : "s"));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/AddLeaveBalanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLeaveBalanceCommand.java
@@ -51,9 +51,22 @@ public class AddLeaveBalanceCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
+        LeaveBalance newLeaveBalance;
+        try {
+            newLeaveBalance = personToEdit.getLeaveBalance().addLeaves(leaveBalance);
+        } catch (IllegalArgumentException iae) {
+            String leaveCapacityString =
+                    personToEdit.getLeaveBalance().getRemainingLeaveCapacity().toString();
+            throw new CommandException(
+                    String.format(Messages.MESSAGE_INVALID_ADD_INPUT,
+                            LeaveBalance.MAX_LEAVES,
+                            "leaves", leaveCapacityString,
+                            leaveCapacityString.equals("1") ? "leave" : "leaves"));
+        }
+
         Person editedPerson = new Person(
                 personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(), personToEdit.getAddress(),
-                personToEdit.getRole(), personToEdit.getLeaveBalance().addLeaves(leaveBalance),
+                personToEdit.getRole(), newLeaveBalance,
                 personToEdit.getLeavesTaken(), personToEdit.getSalary(), personToEdit.getHoursWorked(),
                 personToEdit.getOvertime(), personToEdit.getCalculatedPay(), personToEdit.getTags());
 

--- a/src/main/java/seedu/address/logic/commands/AddLeaveBalanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLeaveBalanceCommand.java
@@ -20,12 +20,12 @@ public class AddLeaveBalanceCommand extends Command {
     public static final String COMMAND_WORD = "addLeaveBalance";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds leaves to the employee identified "
-            + "by the index number used in the last person listing. \n"
+            + "by the index number used in the last employee listing. \n"
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_LEAVE + "NO_OF_LEAVES (must be a positive integer) \n"
             + "Example: " + COMMAND_WORD + " 1 " + PREFIX_LEAVE + "2";
     public static final String MESSAGE_SUCCESS =
-            "Leaves successfully added to person: %1$s";
+            "Leaves successfully added to employee: %1$s (Employee now has %2$s leave%3$s)";
 
     private final Index index;
     private final LeaveBalance leaveBalance;
@@ -56,7 +56,10 @@ public class AddLeaveBalanceCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         model.setViewingPerson(editedPerson);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, editedPerson.toString()));
+        return new CommandResult(String.format(MESSAGE_SUCCESS,
+                editedPerson.getName().toString(),
+                editedPerson.getLeaveBalance().toString(),
+                editedPerson.getLeaveBalance().toString().equals("1") ? "" : "s"));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/AddLeaveBalanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLeaveBalanceCommand.java
@@ -51,6 +51,23 @@ public class AddLeaveBalanceCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
+        Person editedPerson = getUpdatedPerson(personToEdit);
+
+        model.setPerson(personToEdit, editedPerson);
+        model.setViewingPerson(editedPerson);
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, editedPerson.toString()));
+    }
+
+    /**
+     * Returns a {@code Person} object with an updated leave balance.
+     *
+     * @param personToEdit The person object that is to be edited.
+     * @return An updated Person object.
+     * @throws CommandException if the added amount of leaves causes the Person's
+     * leave balance to exceed the maximum allowed amount
+     */
+    private Person getUpdatedPerson(Person personToEdit) throws CommandException {
         LeaveBalance newLeaveBalance;
         try {
             newLeaveBalance = personToEdit.getLeaveBalance().addLeaves(leaveBalance);
@@ -64,16 +81,10 @@ public class AddLeaveBalanceCommand extends Command {
                             leaveCapacityString.equals("1") ? "leave" : "leaves"));
         }
 
-        Person editedPerson = new Person(
-                personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(), personToEdit.getAddress(),
-                personToEdit.getRole(), newLeaveBalance,
+        return new Person(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
+                personToEdit.getAddress(), personToEdit.getRole(), newLeaveBalance,
                 personToEdit.getLeavesTaken(), personToEdit.getSalary(), personToEdit.getHoursWorked(),
                 personToEdit.getOvertime(), personToEdit.getCalculatedPay(), personToEdit.getTags());
-
-        model.setPerson(personToEdit, editedPerson);
-        model.setViewingPerson(editedPerson);
-
-        return new CommandResult(String.format(MESSAGE_SUCCESS, editedPerson.toString()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AssignLeaveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignLeaveCommand.java
@@ -21,12 +21,12 @@ public class AssignLeaveCommand extends Command {
     public static final String COMMAND_WORD = "assignLeave";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Allocates a leave with a date to the employee identified "
-            + "by the index number used in the last person listing. \n"
+            + "by the index number used in the last employee listing. \n"
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_DATE + "DATE (of the format YYYY-MM-DD) \n"
             + "Example: " + COMMAND_WORD + " 1 " + PREFIX_DATE + "2021-10-30";
     public static final String MESSAGE_SUCCESS =
-            "Leave successfully assigned to person: %1$s";
+            "Leave with date %1$s successfully assigned to employee: %2$s";
 
     private final Index index;
     private final LocalDate date;
@@ -78,7 +78,9 @@ public class AssignLeaveCommand extends Command {
         }
         model.setPerson(personToEdit, editedPerson);
         model.setViewingPerson(editedPerson);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, editedPerson.toString()));
+        return new CommandResult(String.format(MESSAGE_SUCCESS,
+                date.toString(),
+                editedPerson.getName().toString()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -6,12 +6,12 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 
 /**
- * Clears the address book.
+ * Clears HeRon.
  */
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "HeRon has been cleared!";
 
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeductHoursWorkedCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeductHoursWorkedCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.commons.util.StringUtil.isNonZeroUnsignedInteger;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HOURSWORKED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_OVERTIME;
 
@@ -57,33 +58,59 @@ public class DeductHoursWorkedCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
-        HoursWorked newHoursWorked;
-        try {
-            newHoursWorked = personToEdit.getHoursWorked().removeHoursWorked(hoursWorked);
-        } catch (IllegalArgumentException iae) {
-            throw new CommandException(
-                    String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT,
-                            hoursWorked, "hours worked", personToEdit.getHoursWorked()));
-        }
-
-        Overtime newOvertime;
-        try {
-            newOvertime = personToEdit.getOvertime().removeOvertime(overtime);
-        } catch (IllegalArgumentException iae) {
-            throw new CommandException(
-                    String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT,
-                            overtime, "overtime hours", personToEdit.getOvertime()));
-        }
-        Person editedPerson = new Person(
-                personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(), personToEdit.getAddress(),
-                personToEdit.getRole(), personToEdit.getLeaveBalance(), personToEdit.getLeavesTaken(),
-                personToEdit.getSalary(), newHoursWorked, newOvertime, personToEdit.getCalculatedPay(),
-                personToEdit.getTags());
+        Person editedPerson = getUpdatedPerson(personToEdit);
 
         model.setPerson(personToEdit, editedPerson);
         model.setViewingPerson(editedPerson);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, editedPerson.toString()));
+    }
+
+    /**
+     * Returns a {@code Person} object with updated hours worked and overtime hours worked.
+     *
+     * @param personToEdit The person object that is to be edited.
+     * @return An updated Person object.
+     * @throws CommandException if the removed amount of hours worked/overtime causes the Person's
+     * hours worked/overtime to exceed the maximum allowed amount
+     */
+    private Person getUpdatedPerson(Person personToEdit) throws CommandException {
+        HoursWorked newHoursWorked = personToEdit.getHoursWorked();
+        try {
+            // Check if hours worked input is a positive integer before calling addHoursWorked
+            if (isNonZeroUnsignedInteger(hoursWorked.toString())) {
+                newHoursWorked = personToEdit.getHoursWorked().removeHoursWorked(hoursWorked);
+            }
+        } catch (IllegalArgumentException iae) {
+            String hoursWorkedString = hoursWorked.toString();
+            String personHoursWorkedString = personToEdit.getHoursWorked().toString();
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT,
+                    hoursWorkedString,
+                    hoursWorkedString.equals("1") ? "hour worked" : "hours worked",
+                    personHoursWorkedString,
+                    personHoursWorkedString.equals("1") ? "hour worked" : "hours worked"));
+        }
+
+        Overtime newOvertime = personToEdit.getOvertime();
+        try {
+            // Check if overtime input is a positive integer before calling addOvertime
+            if (isNonZeroUnsignedInteger(overtime.toString())) {
+                newOvertime = personToEdit.getOvertime().removeOvertime(overtime);
+            }
+        } catch (IllegalArgumentException iae) {
+            String overtimeString = overtime.toString();
+            String personOvertimeString = personToEdit.getOvertime().toString();
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT,
+                    overtimeString,
+                    overtimeString.equals("1") ? "overtime hour worked" : "overtime hours worked",
+                    personOvertimeString,
+                    personOvertimeString.equals("1") ? "overtime hour worked" : "overtime hours worked"));
+        }
+
+        return new Person(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
+                personToEdit.getAddress(), personToEdit.getRole(), personToEdit.getLeaveBalance(),
+                personToEdit.getLeavesTaken(), personToEdit.getSalary(), newHoursWorked, newOvertime,
+                personToEdit.getCalculatedPay(), personToEdit.getTags());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeductHoursWorkedCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeductHoursWorkedCommand.java
@@ -62,7 +62,8 @@ public class DeductHoursWorkedCommand extends Command {
             newHoursWorked = personToEdit.getHoursWorked().removeHoursWorked(hoursWorked);
         } catch (IllegalArgumentException iae) {
             throw new CommandException(
-                    String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT, hoursWorked, "hours worked"));
+                    String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT,
+                            hoursWorked, "hours worked", personToEdit.getHoursWorked()));
         }
 
         Overtime newOvertime;
@@ -70,7 +71,8 @@ public class DeductHoursWorkedCommand extends Command {
             newOvertime = personToEdit.getOvertime().removeOvertime(overtime);
         } catch (IllegalArgumentException iae) {
             throw new CommandException(
-                    String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT, overtime, "overtime hours"));
+                    String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT,
+                            overtime, "overtime hours", personToEdit.getOvertime()));
         }
         Person editedPerson = new Person(
                 personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(), personToEdit.getAddress(),

--- a/src/main/java/seedu/address/logic/commands/DeductHoursWorkedCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeductHoursWorkedCommand.java
@@ -23,13 +23,15 @@ public class DeductHoursWorkedCommand extends Command {
     public static final String COMMAND_WORD = "deductHoursWorked";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deducts hours worked OR overtime from the employee identified "
-            + "by the index number used in the last person listing. \n"
+            + "by the index number used in the last employee listing. \n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_HOURSWORKED + "NO_OF_HOURS_WORKED] (must be a positive integer) "
             + "[" + PREFIX_OVERTIME + "NO_OF_HOURS_WORKED_OVERTIME] (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1 " + PREFIX_HOURSWORKED + "2";
     public static final String MESSAGE_SUCCESS =
-            "Successfully removed hours worked from person: %1$s";
+            "Successfully removed hours worked from employee: %1$s "
+                    + "(Employee now has %2$s hour%3$s worked and "
+                    + "%4$s overtime hour%5$s worked)";
 
     private final Index index;
     private final HoursWorked hoursWorked;
@@ -63,7 +65,12 @@ public class DeductHoursWorkedCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         model.setViewingPerson(editedPerson);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, editedPerson.toString()));
+        return new CommandResult(String.format(MESSAGE_SUCCESS,
+                        editedPerson.getName().toString(),
+                        editedPerson.getHoursWorked().toString(),
+                        editedPerson.getHoursWorked().toString().equals("1") ? "" : "s",
+                        editedPerson.getOvertime().toString(),
+                        editedPerson.getOvertime().toString().equals("1") ? "" : "s"));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/DeductLeaveBalanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeductLeaveBalanceCommand.java
@@ -53,17 +53,25 @@ public class DeductLeaveBalanceCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
-        Person editedPerson;
+        LeaveBalance newLeaveBalance;
         try {
-            editedPerson = new Person(
-                    personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(), personToEdit.getAddress(),
-                    personToEdit.getRole(), personToEdit.getLeaveBalance().removeLeaves(leaveBalance),
-                    personToEdit.getLeavesTaken(), personToEdit.getSalary(), personToEdit.getHoursWorked(),
-                    personToEdit.getOvertime(), personToEdit.getCalculatedPay(), personToEdit.getTags());
+            newLeaveBalance = personToEdit.getLeaveBalance().removeLeaves(leaveBalance);
         } catch (IllegalArgumentException iae) {
+            String leaveBalanceString = leaveBalance.toString();
+            String personLeaveBalanceString = personToEdit.getLeaveBalance().toString();
             throw new CommandException(
-                    String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT, leaveBalance, "leaves"));
+                    String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT,
+                            leaveBalanceString,
+                            leaveBalanceString.equals("1") ? "leave" : "leaves",
+                            personLeaveBalanceString,
+                            personLeaveBalanceString.equals("1") ? "leave" : "leaves"));
         }
+
+        Person editedPerson = new Person(
+                personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(), personToEdit.getAddress(),
+                personToEdit.getRole(), newLeaveBalance,
+                personToEdit.getLeavesTaken(), personToEdit.getSalary(), personToEdit.getHoursWorked(),
+                personToEdit.getOvertime(), personToEdit.getCalculatedPay(), personToEdit.getTags());
 
         model.setPerson(personToEdit, editedPerson);
         model.setViewingPerson(editedPerson);

--- a/src/main/java/seedu/address/logic/commands/DeductLeaveBalanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeductLeaveBalanceCommand.java
@@ -53,30 +53,41 @@ public class DeductLeaveBalanceCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
+        Person editedPerson = getUpdatedPerson(personToEdit);
+
+        model.setPerson(personToEdit, editedPerson);
+        model.setViewingPerson(editedPerson);
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, editedPerson.toString()));
+    }
+
+    /**
+     * Returns a {@code Person} object with an updated leave balance.
+     *
+     * @param personToEdit The person object that is to be edited.
+     * @return An updated Person object.
+     * @throws CommandException if the removed amount of leaves causes the Person's
+     * leave balance to become negative
+     */
+    private Person getUpdatedPerson(Person personToEdit) throws CommandException {
         LeaveBalance newLeaveBalance;
         try {
             newLeaveBalance = personToEdit.getLeaveBalance().removeLeaves(leaveBalance);
         } catch (IllegalArgumentException iae) {
             String leaveBalanceString = leaveBalance.toString();
             String personLeaveBalanceString = personToEdit.getLeaveBalance().toString();
-            throw new CommandException(
-                    String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT,
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT,
                             leaveBalanceString,
                             leaveBalanceString.equals("1") ? "leave" : "leaves",
                             personLeaveBalanceString,
                             personLeaveBalanceString.equals("1") ? "leave" : "leaves"));
         }
 
-        Person editedPerson = new Person(
-                personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(), personToEdit.getAddress(),
-                personToEdit.getRole(), newLeaveBalance,
+        return new Person(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
+                personToEdit.getAddress(), personToEdit.getRole(), newLeaveBalance,
                 personToEdit.getLeavesTaken(), personToEdit.getSalary(), personToEdit.getHoursWorked(),
                 personToEdit.getOvertime(), personToEdit.getCalculatedPay(), personToEdit.getTags());
 
-        model.setPerson(personToEdit, editedPerson);
-        model.setViewingPerson(editedPerson);
-
-        return new CommandResult(String.format(MESSAGE_SUCCESS, editedPerson.toString()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeductLeaveBalanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeductLeaveBalanceCommand.java
@@ -20,14 +20,14 @@ public class DeductLeaveBalanceCommand extends Command {
     public static final String COMMAND_WORD = "deductLeaveBalance";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deducts leaves from the employee identified "
-            + "by the index number used in the last person listing. "
+            + "by the index number used in the last employee listing. "
             + "Number of leaves removed cannot be greater than the amount of leaves "
             + "the employee currently has. \n"
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_LEAVE + "NO_OF_LEAVES (must be a positive integer) \n"
             + "Example: " + COMMAND_WORD + " 1 " + PREFIX_LEAVE + "2";
     public static final String MESSAGE_SUCCESS =
-            "Leaves successfully removed from person: %1$s";
+            "Leaves successfully removed from employee: %1$s (Employee now has %2$s leave%3$s)";
 
     private final Index index;
     private final LeaveBalance leaveBalance;
@@ -58,7 +58,10 @@ public class DeductLeaveBalanceCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         model.setViewingPerson(editedPerson);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, editedPerson.toString()));
+        return new CommandResult(String.format(MESSAGE_SUCCESS,
+                editedPerson.getName().toString(),
+                editedPerson.getLeaveBalance().toString(),
+                editedPerson.getLeaveBalance().toString().equals("1") ? "" : "s"));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -22,7 +22,7 @@ public class DeleteCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_DELETE_EMPLOYEE_SUCCESS = "Deleted Employee: %1$s";
 
     private final Index targetIndex;
 
@@ -41,7 +41,7 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
+        return new CommandResult(String.format(MESSAGE_DELETE_EMPLOYEE_SUCCESS, personToDelete.getName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -45,8 +45,8 @@ public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
-            + "by the index number used in the displayed person list. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the employee identified "
+            + "by the index number used in the displayed employee list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
@@ -63,9 +63,9 @@ public class EditCommand extends Command {
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
 
-    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
+    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Employee: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This employee already exists in HeRon.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -13,11 +13,22 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.HashSet;
 import java.util.function.Predicate;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.CalculatedPay;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.HourlySalary;
+import seedu.address.model.person.HoursWorked;
+import seedu.address.model.person.LeaveBalance;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.Role;
+import seedu.address.model.tag.Tag;
 
 /**
  * Finds and lists all persons in HeRon that passes the given predicate.
@@ -27,7 +38,7 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons who meets "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all employees who meets "
             + "all the specified conditions and displays them as a list with index numbers.\n"
             + "Each condition is tagged with a prefix just like the add command.\n"
             + "For example, to search by name, use n/[name].\n"
@@ -68,6 +79,21 @@ public class FindCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
 
+        if (model.getFilteredPersonList().size() == 0) {
+            // If the filtered list is empty, display a default person
+            HashSet<Tag> egTags = new HashSet<>();
+            egTags.add(new Tag("example"));
+            Person examplePerson = new Person(new Name("Example person"), new Phone("62353535"),
+                    new Email("example@empl.com"), new Address("Example Street, Blk 404"),
+                    new Role("Exemplar"), new LeaveBalance("69"),
+                    new HourlySalary("666"), new HoursWorked("420"),
+                    new CalculatedPay("0"), egTags);
+            model.setViewingPerson(examplePerson);
+        } else {
+            // Else, display the first person
+            Person firstPerson = model.getFilteredPersonList().get(0);
+            model.setViewingPerson(firstPerson);
+        }
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -220,7 +220,7 @@ public class ImportCommand extends Command {
     private LeaveBalance buildLeave(PersonInput input) throws ParseException {
         return input.getLeaves() == null
                 ? new LeaveBalance("0")
-                : ParserUtil.parseLeaves(input.getLeaves());
+                : ParserUtil.parseLeaveBalance(input.getLeaves());
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -12,7 +12,7 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SUCCESS = "Listed all employees.";
 
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/PayCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PayCommand.java
@@ -36,19 +36,20 @@ public class PayCommand extends Command {
     public static final String SPECIAL_COMMAND_PHRASE = "all";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Pays the person identified by the index number used OR all persons in the displayed person list.\n"
+            + ": Pays the employee identified by the index number used "
+            + "OR all employees in the displayed employee list.\n"
             + "Parameters: INDEX (must be a positive integer) OR \"all\"\n"
             + "Example 1: " + COMMAND_WORD + " 1\n"
             + "Example 2: " + COMMAND_WORD + " " + SPECIAL_COMMAND_PHRASE;
 
-    public static final String MESSAGE_PAY_PERSON_SUCCESS = "Successfully paid person: %1$s";
+    public static final String MESSAGE_PAY_PERSON_SUCCESS = "Successfully paid $%1$s to employee: %2$s";
 
     public static final String MESSAGE_PAY_ALL_SUCCESS = "Successfully paid all in the list.";
 
     public static final String MESSAGE_ALREADY_PAID = "The employee: %1$s,\n"
             + "is already paid.";
 
-    public static final String MESSAGE_SKIP_ALREADY_PAID = "These employees have already been paid:\n";
+    public static final String MESSAGE_SKIP_ALREADY_PAID = "These employees have already been paid:";
 
     public static final String MESSAGE_NO_ONE_TO_BE_PAID = "All employees in the list have already been paid.";
 
@@ -109,7 +110,9 @@ public class PayCommand extends Command {
         // View the person that has been paid
         model.setViewingPerson(paidPerson);
 
-        return new CommandResult(String.format(MESSAGE_PAY_PERSON_SUCCESS, paidPerson));
+        return new CommandResult(String.format(MESSAGE_PAY_PERSON_SUCCESS,
+                personToPay.getCalculatedPay().toString(),
+                paidPerson.getName().toString()));
     }
 
     private CommandResult executePayAll(Model model) throws CommandException {
@@ -156,7 +159,7 @@ public class PayCommand extends Command {
             StringBuilder messageBuilder = new StringBuilder(MESSAGE_PAY_ALL_SUCCESS).append("\n")
                     .append(MESSAGE_SKIP_ALREADY_PAID).append("\n");
             for (Person personSkipped: personsSkippedList) {
-                messageBuilder.append(String.format("Skipped employee: %s\n", personSkipped.toString()));
+                messageBuilder.append(String.format("Skipped employee: %s\n", personSkipped.getName().toString()));
             }
             commandSuccessMessage = messageBuilder.toString().trim();
         }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -59,7 +59,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
 
         Role role = ParserUtil.parseRole(argMultimap.getValue(PREFIX_ROLE).get());
-        LeaveBalance leaveBalance = ParserUtil.parseLeaves(argMultimap.getValue(PREFIX_LEAVE).get());
+        LeaveBalance leaveBalance = ParserUtil.parseLeaveBalance(argMultimap.getValue(PREFIX_LEAVE).get());
         // Add command does not allow adding of dates to leavesTaken
         LeavesTaken leavesTaken = new LeavesTaken();
         HourlySalary hourlySalary = ParserUtil.parseSalary(argMultimap.getValue(PREFIX_HOURLYSALARY).get());

--- a/src/main/java/seedu/address/logic/parser/AddHoursWorkedCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddHoursWorkedCommandParser.java
@@ -2,7 +2,9 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_INTEGER_INPUT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_HOURS_WORKED_INPUT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_OVERTIME_INPUT;
+import static seedu.address.commons.util.StringUtil.isNonNegativeInteger;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HOURSWORKED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_OVERTIME;
 
@@ -47,25 +49,70 @@ public class AddHoursWorkedCommandParser implements Parser<AddHoursWorkedCommand
                     AddHoursWorkedCommand.MESSAGE_USAGE));
         }
 
-        String hoursWorkedString = argMultimap.getValue(PREFIX_HOURSWORKED).orElse("0");
-        String overtimeString = argMultimap.getValue(PREFIX_OVERTIME).orElse("0");
-
-        int hoursWorked;
-        int overtime;
-        try {
-            hoursWorked = Integer.parseInt(hoursWorkedString);
-            overtime = Integer.parseInt(overtimeString);
-        } catch (NumberFormatException nfe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_INTEGER_INPUT,
-                    AddHoursWorkedCommand.MESSAGE_USAGE), nfe);
+        // If either prefix contains a 0, reject the input
+        if (argMultimap.getValue(PREFIX_HOURSWORKED).isPresent()
+                && argMultimap.getValue(PREFIX_HOURSWORKED).get().equals("0")) {
+            throw new ParseException(String.format(MESSAGE_INVALID_HOURS_WORKED_INPUT,
+                    AddHoursWorkedCommand.MESSAGE_USAGE));
         }
-        // At least one of the inputs must be a positive integer
-        if (hoursWorked <= 0 && overtime <= 0) {
-            throw new ParseException(String.format(MESSAGE_INVALID_INTEGER_INPUT,
+        if (argMultimap.getValue(PREFIX_OVERTIME).isPresent()
+                && argMultimap.getValue(PREFIX_OVERTIME).get().equals("0")) {
+            throw new ParseException(String.format(MESSAGE_INVALID_OVERTIME_INPUT,
                     AddHoursWorkedCommand.MESSAGE_USAGE));
         }
 
-        return new AddHoursWorkedCommand(index, new HoursWorked(hoursWorkedString),
-                new Overtime(overtimeString));
+        String hoursWorkedString = argMultimap.getValue(PREFIX_HOURSWORKED).orElse("0");
+        String overtimeString = argMultimap.getValue(PREFIX_OVERTIME).orElse("0");
+
+        return new AddHoursWorkedCommand(index, parseHoursWorkedString(hoursWorkedString),
+                parseOvertimeString(overtimeString));
+    }
+
+    /**
+     * Parses the given {@code String} that represents the number of hours worked into a
+     * HoursWorked object that contains that number of hours worked.
+     *
+     * @param hoursWorkedString A string representing the number of hours worked.
+     * @return A new HoursWorked object.
+     * @throws ParseException if an invalid integer input for the hours worked is given.
+     */
+    private HoursWorked parseHoursWorkedString(String hoursWorkedString) throws ParseException {
+        if (!isNonNegativeInteger(hoursWorkedString)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_HOURS_WORKED_INPUT,
+                    AddHoursWorkedCommand.MESSAGE_USAGE));
+        }
+
+        HoursWorked hoursWorked;
+        try {
+            hoursWorked = new HoursWorked(hoursWorkedString);
+        } catch (IllegalArgumentException iae) {
+            throw new ParseException(String.format(MESSAGE_INVALID_HOURS_WORKED_INPUT,
+                    AddHoursWorkedCommand.MESSAGE_USAGE));
+        }
+        return hoursWorked;
+    }
+
+    /**
+     * Parses the given {@code String} that represents the number of overtime hours worked into a
+     * Overtime object that contains that number of overtime hours worked.
+     *
+     * @param overtimeString A string representing the number of overtime hours worked.
+     * @return A new Overtime object.
+     * @throws ParseException if an invalid integer input for the overtime hours worked is given.
+     */
+    private Overtime parseOvertimeString(String overtimeString) throws ParseException {
+        if (!isNonNegativeInteger(overtimeString)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_OVERTIME_INPUT,
+                    AddHoursWorkedCommand.MESSAGE_USAGE));
+        }
+
+        Overtime overtime;
+        try {
+            overtime = new Overtime(overtimeString);
+        } catch (IllegalArgumentException iae) {
+            throw new ParseException(String.format(MESSAGE_INVALID_OVERTIME_INPUT,
+                    AddHoursWorkedCommand.MESSAGE_USAGE));
+        }
+        return overtime;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddLeaveBalanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddLeaveBalanceCommandParser.java
@@ -58,7 +58,7 @@ public class AddLeaveBalanceCommandParser implements Parser<AddLeaveBalanceComma
      */
     private LeaveBalance parseLeaveString(String numberOfLeavesString) throws ParseException {
         // If a non-positive integer is given, reject the input
-        if (isNonZeroUnsignedInteger(numberOfLeavesString)) {
+        if (!isNonZeroUnsignedInteger(numberOfLeavesString)) {
             throw new ParseException(String.format(MESSAGE_INVALID_LEAVES_INPUT,
                     AddLeaveBalanceCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/AddLeaveBalanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddLeaveBalanceCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_LEAVES_INPUT;
+import static seedu.address.commons.util.StringUtil.isNonZeroUnsignedInteger;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LEAVE;
 
 import seedu.address.commons.core.index.Index;
@@ -56,15 +57,8 @@ public class AddLeaveBalanceCommandParser implements Parser<AddLeaveBalanceComma
      * @throws ParseException if an invalid integer input for the number of leaves is given.
      */
     private LeaveBalance parseLeaveString(String numberOfLeavesString) throws ParseException {
-        int numberOfLeaves;
-        try {
-            numberOfLeaves = Integer.parseInt(numberOfLeavesString);
-        } catch (NumberFormatException nfe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_LEAVES_INPUT,
-                    AddLeaveBalanceCommand.MESSAGE_USAGE), nfe);
-        }
-        // If a non-positive integer is given
-        if (numberOfLeaves <= 0) {
+        // If a non-positive integer is given, reject the input
+        if (isNonZeroUnsignedInteger(numberOfLeavesString)) {
             throw new ParseException(String.format(MESSAGE_INVALID_LEAVES_INPUT,
                     AddLeaveBalanceCommand.MESSAGE_USAGE));
         }
@@ -78,5 +72,4 @@ public class AddLeaveBalanceCommandParser implements Parser<AddLeaveBalanceComma
         }
         return leaveBalance;
     }
-
 }

--- a/src/main/java/seedu/address/logic/parser/AddLeaveBalanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddLeaveBalanceCommandParser.java
@@ -2,7 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_INTEGER_INPUT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_LEAVES_INPUT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LEAVE;
 
 import seedu.address.commons.core.index.Index;
@@ -44,20 +44,39 @@ public class AddLeaveBalanceCommandParser implements Parser<AddLeaveBalanceComma
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AddLeaveBalanceCommand.MESSAGE_USAGE));
         }
+        return new AddLeaveBalanceCommand(index, parseLeaveString(numberOfLeavesString));
+    }
+
+    /**
+     * Parses the given {@code String} that represents a number of leaves into a
+     * LeaveBalance object that contains that number of leaves.
+     *
+     * @param numberOfLeavesString A string representing the number of leaves.
+     * @return A new LeaveBalance object.
+     * @throws ParseException if an invalid integer input for the number of leaves is given.
+     */
+    private LeaveBalance parseLeaveString(String numberOfLeavesString) throws ParseException {
         int numberOfLeaves;
         try {
             numberOfLeaves = Integer.parseInt(numberOfLeavesString);
         } catch (NumberFormatException nfe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_INTEGER_INPUT,
+            throw new ParseException(String.format(MESSAGE_INVALID_LEAVES_INPUT,
                     AddLeaveBalanceCommand.MESSAGE_USAGE), nfe);
         }
         // If a non-positive integer is given
         if (numberOfLeaves <= 0) {
-            throw new ParseException(String.format(MESSAGE_INVALID_INTEGER_INPUT,
+            throw new ParseException(String.format(MESSAGE_INVALID_LEAVES_INPUT,
                     AddLeaveBalanceCommand.MESSAGE_USAGE));
         }
 
-        return new AddLeaveBalanceCommand(index, new LeaveBalance(numberOfLeavesString));
+        LeaveBalance leaveBalance;
+        try {
+            leaveBalance = new LeaveBalance(numberOfLeavesString);
+        } catch (IllegalArgumentException iae) {
+            throw new ParseException(String.format(MESSAGE_INVALID_LEAVES_INPUT,
+                    AddLeaveBalanceCommand.MESSAGE_USAGE), iae);
+        }
+        return leaveBalance;
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/DeductHoursWorkedCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeductHoursWorkedCommandParser.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_INTEGER_INPUT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_HOURS_WORKED_INPUT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_OVERTIME_INPUT;
+import static seedu.address.commons.util.StringUtil.isNonNegativeInteger;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HOURSWORKED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_OVERTIME;
 
@@ -46,25 +48,70 @@ public class DeductHoursWorkedCommandParser implements Parser<DeductHoursWorkedC
                     DeductHoursWorkedCommand.MESSAGE_USAGE));
         }
 
-        String hoursWorkedString = argMultimap.getValue(PREFIX_HOURSWORKED).orElse("0");
-        String overtimeString = argMultimap.getValue(PREFIX_OVERTIME).orElse("0");
-
-        int hoursWorked;
-        int overtime;
-        try {
-            hoursWorked = Integer.parseInt(hoursWorkedString);
-            overtime = Integer.parseInt(overtimeString);
-        } catch (NumberFormatException nfe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_INTEGER_INPUT,
-                    DeductHoursWorkedCommand.MESSAGE_USAGE), nfe);
+        // If either prefix contains a 0, reject the input
+        if (argMultimap.getValue(PREFIX_HOURSWORKED).isPresent()
+                && argMultimap.getValue(PREFIX_HOURSWORKED).get().equals("0")) {
+            throw new ParseException(String.format(MESSAGE_INVALID_HOURS_WORKED_INPUT,
+                    DeductHoursWorkedCommand.MESSAGE_USAGE));
         }
-        // At least one of the inputs must be a positive integer
-        if (hoursWorked <= 0 && overtime <= 0) {
-            throw new ParseException(String.format(MESSAGE_INVALID_INTEGER_INPUT,
+        if (argMultimap.getValue(PREFIX_OVERTIME).isPresent()
+                && argMultimap.getValue(PREFIX_OVERTIME).get().equals("0")) {
+            throw new ParseException(String.format(MESSAGE_INVALID_OVERTIME_INPUT,
                     DeductHoursWorkedCommand.MESSAGE_USAGE));
         }
 
-        return new DeductHoursWorkedCommand(index, new HoursWorked(hoursWorkedString),
-                new Overtime(overtimeString));
+        String hoursWorkedString = argMultimap.getValue(PREFIX_HOURSWORKED).orElse("0");
+        String overtimeString = argMultimap.getValue(PREFIX_OVERTIME).orElse("0");
+
+        return new DeductHoursWorkedCommand(index, parseHoursWorkedString(hoursWorkedString),
+                parseOvertimeString(overtimeString));
+    }
+
+    /**
+     * Parses the given {@code String} that represents the number of hours worked into a
+     * HoursWorked object that contains that number of hours worked.
+     *
+     * @param hoursWorkedString A string representing the number of hours worked.
+     * @return A new HoursWorked object.
+     * @throws ParseException if an invalid integer input for the hours worked is given.
+     */
+    private HoursWorked parseHoursWorkedString(String hoursWorkedString) throws ParseException {
+        if (!isNonNegativeInteger(hoursWorkedString)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_HOURS_WORKED_INPUT,
+                    DeductHoursWorkedCommand.MESSAGE_USAGE));
+        }
+
+        HoursWorked hoursWorked;
+        try {
+            hoursWorked = new HoursWorked(hoursWorkedString);
+        } catch (IllegalArgumentException iae) {
+            throw new ParseException(String.format(MESSAGE_INVALID_HOURS_WORKED_INPUT,
+                    DeductHoursWorkedCommand.MESSAGE_USAGE));
+        }
+        return hoursWorked;
+    }
+
+    /**
+     * Parses the given {@code String} that represents the number of overtime hours worked into a
+     * Overtime object that contains that number of overtime hours worked.
+     *
+     * @param overtimeString A string representing the number of overtime hours worked.
+     * @return A new Overtime object.
+     * @throws ParseException if an invalid integer input for the overtime hours worked is given.
+     */
+    private Overtime parseOvertimeString(String overtimeString) throws ParseException {
+        if (!isNonNegativeInteger(overtimeString)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_OVERTIME_INPUT,
+                    DeductHoursWorkedCommand.MESSAGE_USAGE));
+        }
+
+        Overtime overtime;
+        try {
+            overtime = new Overtime(overtimeString);
+        } catch (IllegalArgumentException iae) {
+            throw new ParseException(String.format(MESSAGE_INVALID_OVERTIME_INPUT,
+                    DeductHoursWorkedCommand.MESSAGE_USAGE));
+        }
+        return overtime;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeductLeaveBalanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeductLeaveBalanceCommandParser.java
@@ -2,7 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_INTEGER_INPUT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_LEAVES_INPUT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LEAVE;
 
 import seedu.address.commons.core.index.Index;
@@ -44,19 +44,39 @@ public class DeductLeaveBalanceCommandParser implements Parser<DeductLeaveBalanc
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     DeductLeaveBalanceCommand.MESSAGE_USAGE));
         }
+
+        return new DeductLeaveBalanceCommand(index, parseLeaveString(numberOfLeavesString));
+    }
+
+    /**
+     * Parses the given {@code String} that represents a number of leaves into a
+     * LeaveBalance object that contains that number of leaves.
+     *
+     * @param numberOfLeavesString A string representing the number of leaves.
+     * @return A new LeaveBalance object.
+     * @throws ParseException if an invalid integer input for the number of leaves is given.
+     */
+    private LeaveBalance parseLeaveString(String numberOfLeavesString) throws ParseException {
         int numberOfLeaves;
         try {
             numberOfLeaves = Integer.parseInt(numberOfLeavesString);
         } catch (NumberFormatException nfe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_INTEGER_INPUT,
+            throw new ParseException(String.format(MESSAGE_INVALID_LEAVES_INPUT,
                     DeductLeaveBalanceCommand.MESSAGE_USAGE), nfe);
         }
         // If a non-positive integer is given
         if (numberOfLeaves <= 0) {
-            throw new ParseException(String.format(MESSAGE_INVALID_INTEGER_INPUT,
+            throw new ParseException(String.format(MESSAGE_INVALID_LEAVES_INPUT,
                     DeductLeaveBalanceCommand.MESSAGE_USAGE));
         }
 
-        return new DeductLeaveBalanceCommand(index, new LeaveBalance(numberOfLeavesString));
+        LeaveBalance leaveBalance;
+        try {
+            leaveBalance = new LeaveBalance(numberOfLeavesString);
+        } catch (IllegalArgumentException iae) {
+            throw new ParseException(String.format(MESSAGE_INVALID_LEAVES_INPUT,
+                    DeductLeaveBalanceCommand.MESSAGE_USAGE), iae);
+        }
+        return leaveBalance;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeductLeaveBalanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeductLeaveBalanceCommandParser.java
@@ -3,10 +3,12 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_LEAVES_INPUT;
+import static seedu.address.commons.util.StringUtil.isNonZeroUnsignedInteger;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LEAVE;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.AddLeaveBalanceCommand;
 import seedu.address.logic.commands.DeductLeaveBalanceCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.LeaveBalance;
@@ -57,17 +59,10 @@ public class DeductLeaveBalanceCommandParser implements Parser<DeductLeaveBalanc
      * @throws ParseException if an invalid integer input for the number of leaves is given.
      */
     private LeaveBalance parseLeaveString(String numberOfLeavesString) throws ParseException {
-        int numberOfLeaves;
-        try {
-            numberOfLeaves = Integer.parseInt(numberOfLeavesString);
-        } catch (NumberFormatException nfe) {
+        // If a non-positive integer is given, reject the input
+        if (isNonZeroUnsignedInteger(numberOfLeavesString)) {
             throw new ParseException(String.format(MESSAGE_INVALID_LEAVES_INPUT,
-                    DeductLeaveBalanceCommand.MESSAGE_USAGE), nfe);
-        }
-        // If a non-positive integer is given
-        if (numberOfLeaves <= 0) {
-            throw new ParseException(String.format(MESSAGE_INVALID_LEAVES_INPUT,
-                    DeductLeaveBalanceCommand.MESSAGE_USAGE));
+                    AddLeaveBalanceCommand.MESSAGE_USAGE));
         }
 
         LeaveBalance leaveBalance;

--- a/src/main/java/seedu/address/logic/parser/DeductLeaveBalanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeductLeaveBalanceCommandParser.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_LEAVE;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.logic.commands.AddLeaveBalanceCommand;
 import seedu.address.logic.commands.DeductLeaveBalanceCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.LeaveBalance;
@@ -62,7 +61,7 @@ public class DeductLeaveBalanceCommandParser implements Parser<DeductLeaveBalanc
         // If a non-positive integer is given, reject the input
         if (!isNonZeroUnsignedInteger(numberOfLeavesString)) {
             throw new ParseException(String.format(MESSAGE_INVALID_LEAVES_INPUT,
-                    AddLeaveBalanceCommand.MESSAGE_USAGE));
+                    DeductLeaveBalanceCommand.MESSAGE_USAGE));
         }
 
         LeaveBalance leaveBalance;

--- a/src/main/java/seedu/address/logic/parser/DeductLeaveBalanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeductLeaveBalanceCommandParser.java
@@ -60,7 +60,7 @@ public class DeductLeaveBalanceCommandParser implements Parser<DeductLeaveBalanc
      */
     private LeaveBalance parseLeaveString(String numberOfLeavesString) throws ParseException {
         // If a non-positive integer is given, reject the input
-        if (isNonZeroUnsignedInteger(numberOfLeavesString)) {
+        if (!isNonZeroUnsignedInteger(numberOfLeavesString)) {
             throw new ParseException(String.format(MESSAGE_INVALID_LEAVES_INPUT,
                     AddLeaveBalanceCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -66,7 +66,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.setRole(ParserUtil.parseRole(argMultimap.getValue(PREFIX_ROLE).get()));
         }
         if (argMultimap.getValue(PREFIX_LEAVE).isPresent()) {
-            editPersonDescriptor.setLeaves(ParserUtil.parseLeaves(argMultimap.getValue(PREFIX_LEAVE).get()));
+            editPersonDescriptor.setLeaves(ParserUtil.parseLeaveBalance(argMultimap.getValue(PREFIX_LEAVE).get()));
         }
         if (argMultimap.getValue(PREFIX_HOURLYSALARY).isPresent()) {
             editPersonDescriptor.setSalary(ParserUtil.parseSalary(argMultimap.getValue(PREFIX_HOURLYSALARY).get()));

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -118,13 +118,12 @@ public class ParserUtil {
     }
 
     /**
->>>>>>> master
-     * Parses a {@code String amount} into a {@code Leaves}.
+     * Parses a {@code String amount} into a {@code LeaveBalance}.
      * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if the given {@code amount} is invalid.
      */
-    public static LeaveBalance parseLeaves(String amount) throws ParseException {
+    public static LeaveBalance parseLeaveBalance(String amount) throws ParseException {
         requireNonNull(amount);
         String trimmedAmount = amount.trim();
         if (!LeaveBalance.isValidLeaveBalance(trimmedAmount)) {

--- a/src/main/java/seedu/address/model/person/HoursWorked.java
+++ b/src/main/java/seedu/address/model/person/HoursWorked.java
@@ -9,8 +9,12 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class HoursWorked {
 
+    public static final int MIN_HOURS_WORKED = 0;
+    public static final int MAX_HOURS_WORKED = 744; // 24 hours * 31 days
     public static final String MESSAGE_CONSTRAINTS =
-            "HoursWorked should only contain positive integers, and it should not be blank";
+            "Hours Worked should only contain an integer value between "
+                    + MIN_HOURS_WORKED + " and " + MAX_HOURS_WORKED
+                    + " (both inclusive), and it should not be blank";
 
     public final int value;
 
@@ -32,7 +36,7 @@ public class HoursWorked {
         requireNonNull(test);
         try {
             int amount = Integer.parseInt(test);
-            return amount >= 0;
+            return amount >= MIN_HOURS_WORKED && amount <= MAX_HOURS_WORKED && !test.contains("-");
         } catch (NumberFormatException e) {
             return false;
         }
@@ -43,9 +47,15 @@ public class HoursWorked {
      *
      * @param hoursWorked The number of hours worked to be added.
      * @return An updated HoursWorked object.
+     * @throws IllegalArgumentException if the amount of hours worked to be added
+     * causes the total hours worked to exceed the maximum allowed hours worked .
      */
     public HoursWorked addHoursWorked(HoursWorked hoursWorked) {
+        assert(hoursWorked.value > 0);
         int updatedValue = value + hoursWorked.value;
+        if (updatedValue > MAX_HOURS_WORKED) {
+            throw new IllegalArgumentException();
+        }
         return new HoursWorked(String.valueOf(updatedValue));
     }
 
@@ -58,11 +68,24 @@ public class HoursWorked {
      * is greater than the current number of hours worked.
      */
     public HoursWorked removeHoursWorked(HoursWorked hoursWorked) {
+        assert(hoursWorked.value > 0);
         int updatedValue = value - hoursWorked.value;
-        if (updatedValue < 0) {
+        if (updatedValue < MIN_HOURS_WORKED) {
             throw new IllegalArgumentException();
         }
         return new HoursWorked(String.valueOf(updatedValue));
+    }
+
+    /**
+     * Returns an HoursWorked object that represents how many hours worked
+     * can be added to this person without going over the hours worked limit.
+     *
+     * @return An HoursWorked object containing the remaining hours worked capacity of the Person.
+     */
+    public HoursWorked getRemainingHoursWorkedCapacity() {
+        int hoursWorkedCapacity = MAX_HOURS_WORKED - value;
+        assert(hoursWorkedCapacity >= 0);
+        return new HoursWorked(String.valueOf(hoursWorkedCapacity));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/LeaveBalance.java
+++ b/src/main/java/seedu/address/model/person/LeaveBalance.java
@@ -9,6 +9,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class LeaveBalance {
 
+    public static final int MIN_LEAVES = 0;
+    public static final int MAX_LEAVES = 365;
     public static final String MESSAGE_CONSTRAINTS =
             "Leaves should only contain non-negative integers, and it should not be blank";
 
@@ -35,37 +37,54 @@ public class LeaveBalance {
         requireNonNull(test);
         try {
             int amount = Integer.parseInt(test);
-            return amount >= 0;
+            return amount >= MIN_LEAVES && amount <= MAX_LEAVES;
         } catch (NumberFormatException e) {
             return false;
         }
     }
 
     /**
-     * Returns an updated Leaves object with the specified number of leaves added.
+     * Returns an updated LeaveBalance object with the specified number of leaves added.
      *
      * @param leaveBalance The amount of leaves to be added.
-     * @return An updated Leaves object.
+     * @return An updated LeaveBalance object.
+     * @throws IllegalArgumentException if the amount of leaves to be added
+     * causes the total leaves to exceed the maximum allowed number of leaves.
      */
     public LeaveBalance addLeaves(LeaveBalance leaveBalance) {
         int updatedValue = value + leaveBalance.value;
+        if (updatedValue > MAX_LEAVES) {
+            throw new IllegalArgumentException();
+        }
         return new LeaveBalance(String.valueOf(updatedValue));
     }
 
     /**
-     * Returns an updated Leaves object with the specified number of leaves removed.
+     * Returns an updated LeaveBalance object with the specified number of leaves removed.
      *
      * @param leaveBalance The amount of leaves to be removed.
-     * @return An updated Leaves object.
+     * @return An updated LeaveBalance object.
      * @throws IllegalArgumentException if the amount of leaves to be removed
      * is greater than the current amount of leaves.
      */
     public LeaveBalance removeLeaves(LeaveBalance leaveBalance) {
         int updatedValue = value - leaveBalance.value;
-        if (updatedValue < 0) {
+        if (updatedValue < MIN_LEAVES) {
             throw new IllegalArgumentException();
         }
         return new LeaveBalance(String.valueOf(updatedValue));
+    }
+
+    /**
+     * Returns an LeaveBalance object that represents how many leaves
+     * can be added to this person without going over the leave balance limit.
+     *
+     * @return A LeaveBalance object containing the remaining leave capacity of the Person.
+     */
+    public LeaveBalance getRemainingLeaveCapacity() {
+        int leaveCapacity = MAX_LEAVES - value;
+        assert(leaveCapacity >= 0);
+        return new LeaveBalance(String.valueOf(leaveCapacity));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/LeaveBalance.java
+++ b/src/main/java/seedu/address/model/person/LeaveBalance.java
@@ -12,7 +12,8 @@ public class LeaveBalance {
     public static final int MIN_LEAVES = 0;
     public static final int MAX_LEAVES = 365;
     public static final String MESSAGE_CONSTRAINTS =
-            "Leaves should only contain non-negative integers, and it should not be blank";
+            "Leave Balance must be an integer value between 0 and 365 (both inclusive), "
+                    + "and it should not be blank";
 
     public final int value;
 

--- a/src/main/java/seedu/address/model/person/LeaveBalance.java
+++ b/src/main/java/seedu/address/model/person/LeaveBalance.java
@@ -12,8 +12,9 @@ public class LeaveBalance {
     public static final int MIN_LEAVES = 0;
     public static final int MAX_LEAVES = 365;
     public static final String MESSAGE_CONSTRAINTS =
-            "Leave Balance must be an integer value between 0 and 365 (both inclusive), "
-                    + "and it should not be blank";
+            "Leave Balance should only contain an integer value between "
+                    + MIN_LEAVES + " and " + MAX_LEAVES
+                    + " (both inclusive), and it should not be blank";
 
     public final int value;
 
@@ -38,7 +39,7 @@ public class LeaveBalance {
         requireNonNull(test);
         try {
             int amount = Integer.parseInt(test);
-            return amount >= MIN_LEAVES && amount <= MAX_LEAVES;
+            return amount >= MIN_LEAVES && amount <= MAX_LEAVES && !test.contains("-");
         } catch (NumberFormatException e) {
             return false;
         }
@@ -53,6 +54,7 @@ public class LeaveBalance {
      * causes the total leaves to exceed the maximum allowed number of leaves.
      */
     public LeaveBalance addLeaves(LeaveBalance leaveBalance) {
+        assert(leaveBalance.value > 0);
         int updatedValue = value + leaveBalance.value;
         if (updatedValue > MAX_LEAVES) {
             throw new IllegalArgumentException();
@@ -69,6 +71,7 @@ public class LeaveBalance {
      * is greater than the current amount of leaves.
      */
     public LeaveBalance removeLeaves(LeaveBalance leaveBalance) {
+        assert(leaveBalance.value > 0);
         int updatedValue = value - leaveBalance.value;
         if (updatedValue < MIN_LEAVES) {
             throw new IllegalArgumentException();
@@ -77,7 +80,7 @@ public class LeaveBalance {
     }
 
     /**
-     * Returns an LeaveBalance object that represents how many leaves
+     * Returns a LeaveBalance object that represents how many leaves
      * can be added to this person without going over the leave balance limit.
      *
      * @return A LeaveBalance object containing the remaining leave capacity of the Person.

--- a/src/main/java/seedu/address/model/person/Overtime.java
+++ b/src/main/java/seedu/address/model/person/Overtime.java
@@ -9,8 +9,12 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Overtime {
 
+    public static final int MIN_OVERTIME = 0;
+    public static final int MAX_OVERTIME = 744; // 24 hours * 31 days
     public static final String MESSAGE_CONSTRAINTS =
-            "Overtime should only contain a non-negative integer, and it should not be blank";
+            "Overtime should only contain an integer value between "
+                    + MIN_OVERTIME + " and " + MAX_OVERTIME
+                    + " (both inclusive), and it should not be blank";
 
     public final int value;
 
@@ -31,7 +35,7 @@ public class Overtime {
     public static boolean isValidOvertime(String test) {
         try {
             int amount = Integer.parseInt(test);
-            return amount >= 0;
+            return amount >= MIN_OVERTIME && amount <= MAX_OVERTIME && !test.contains("-");
         } catch (NumberFormatException e) {
             return false;
         }
@@ -42,9 +46,15 @@ public class Overtime {
      *
      * @param overtime The number of overtime hours to be added.
      * @return An updated Overtime object.
+     * @throws IllegalArgumentException if the amount of overtime to be added
+     * causes the total overtime to exceed the maximum allowed overtime.
      */
     public Overtime addOvertime(Overtime overtime) {
+        assert(overtime.value > 0);
         int updatedValue = value + overtime.value;
+        if (updatedValue > MAX_OVERTIME) {
+            throw new IllegalArgumentException();
+        }
         return new Overtime(String.valueOf(updatedValue));
     }
 
@@ -57,11 +67,24 @@ public class Overtime {
      * is greater than the current number of overtime hours.
      */
     public Overtime removeOvertime(Overtime overtime) {
+        assert(overtime.value > 0);
         int updatedValue = value - overtime.value;
-        if (updatedValue < 0) {
+        if (updatedValue < MIN_OVERTIME) {
             throw new IllegalArgumentException();
         }
         return new Overtime(String.valueOf(updatedValue));
+    }
+
+    /**
+     * Returns an Overtime object that represents how many overtime worked
+     * can be added to this person without going over the overtime hours worked limit.
+     *
+     * @return An Overtime object containing the remaining overtime hours worked capacity of the Person.
+     */
+    public Overtime getRemainingOvertimeCapacity() {
+        int overtimeWorkedCapacity = MAX_OVERTIME - value;
+        assert(overtimeWorkedCapacity >= 0);
+        return new Overtime(String.valueOf(overtimeWorkedCapacity));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -201,9 +201,7 @@ public class Person {
                 .append("; Salary: ")
                 .append(getSalary())
                 .append("; Hours Worked: ")
-                .append(getHoursWorked())
-                .append("; Leaves Taken: ")
-                .append(getLeavesTaken());
+                .append(getHoursWorked());
 
         Set<Tag> tags = getTags();
         if (!tags.isEmpty()) {

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -40,7 +40,7 @@ public class AddCommandIntegrationTest {
     @Test
     public void execute_duplicatePerson_throwsCommandException() {
         Person personInList = model.getAddressBook().getPersonList().get(0);
-        assertCommandFailure(new AddCommand(personInList), model, AddCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(new AddCommand(personInList), model, AddCommand.MESSAGE_DUPLICATE_EMPLOYEE);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -49,7 +49,7 @@ public class AddCommandTest {
         AddCommand addCommand = new AddCommand(validPerson);
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
+        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_EMPLOYEE, () -> addCommand.execute(modelStub));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -49,7 +49,8 @@ public class AddCommandTest {
         AddCommand addCommand = new AddCommand(validPerson);
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_EMPLOYEE, () -> addCommand.execute(modelStub));
+        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_EMPLOYEE, () ->
+                addCommand.execute(modelStub));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AddHoursWorkedCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddHoursWorkedCommandTest.java
@@ -69,8 +69,12 @@ public class AddHoursWorkedCommandTest {
 
         Person personWithAddedHours = createPersonWithAddedHours(personToAddHoursTo, addedHoursWorked, addedOvertime);
 
-        String expectedMessage =
-                String.format(AddHoursWorkedCommand.MESSAGE_SUCCESS, personWithAddedHours);
+        String expectedMessage = String.format(AddHoursWorkedCommand.MESSAGE_SUCCESS,
+                        personWithAddedHours.getName().toString(),
+                        personWithAddedHours.getHoursWorked().toString(),
+                        personWithAddedHours.getHoursWorked().toString().equals("1") ? "" : "s",
+                        personWithAddedHours.getOvertime().toString(),
+                        personWithAddedHours.getOvertime().toString().equals("1") ? "" : "s");
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.setPerson(personToAddHoursTo, personWithAddedHours);
@@ -97,8 +101,12 @@ public class AddHoursWorkedCommandTest {
 
         Person personWithAddedHours = createPersonWithAddedHours(personToAddHoursTo, addedHoursWorked, addedOvertime);
 
-        String expectedMessage =
-                String.format(AddHoursWorkedCommand.MESSAGE_SUCCESS, personWithAddedHours);
+        String expectedMessage = String.format(AddHoursWorkedCommand.MESSAGE_SUCCESS,
+                personWithAddedHours.getName().toString(),
+                personWithAddedHours.getHoursWorked().toString(),
+                personWithAddedHours.getHoursWorked().toString().equals("1") ? "" : "s",
+                personWithAddedHours.getOvertime().toString(),
+                personWithAddedHours.getOvertime().toString().equals("1") ? "" : "s");
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);

--- a/src/test/java/seedu/address/logic/commands/AddLeaveBalanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddLeaveBalanceCommandTest.java
@@ -64,8 +64,10 @@ public class AddLeaveBalanceCommandTest {
 
         Person personWithAddedLeaves = createPersonWithAddedLeaves(personToAddLeavesTo, addedLeaves);
 
-        String expectedMessage =
-                String.format(AddLeaveBalanceCommand.MESSAGE_SUCCESS, personWithAddedLeaves);
+        String expectedMessage = String.format(AddLeaveBalanceCommand.MESSAGE_SUCCESS,
+                personWithAddedLeaves.getName().toString(),
+                personWithAddedLeaves.getLeaveBalance().toString(),
+                personWithAddedLeaves.getLeaveBalance().toString().equals("1") ? "" : "s");
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.setPerson(personToAddLeavesTo, personWithAddedLeaves);
@@ -90,8 +92,10 @@ public class AddLeaveBalanceCommandTest {
 
         Person personWithAddedLeaves = createPersonWithAddedLeaves(personToAddLeavesTo, addedLeaves);
 
-        String expectedMessage =
-                String.format(AddLeaveBalanceCommand.MESSAGE_SUCCESS, personWithAddedLeaves);
+        String expectedMessage = String.format(AddLeaveBalanceCommand.MESSAGE_SUCCESS,
+                personWithAddedLeaves.getName().toString(),
+                personWithAddedLeaves.getLeaveBalance().toString(),
+                personWithAddedLeaves.getLeaveBalance().toString().equals("1") ? "" : "s");
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);

--- a/src/test/java/seedu/address/logic/commands/DeductHoursWorkedCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeductHoursWorkedCommandTest.java
@@ -40,8 +40,8 @@ public class DeductHoursWorkedCommandTest {
     private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private final HoursWorked removedHoursWorked = new HoursWorked("10");
     private final Overtime removedOvertime = new Overtime("5");
-    private final HoursWorked invalidRemovedHoursWorked = new HoursWorked("1000");
-    private final Overtime invalidRemovedOvertime = new Overtime("1000");
+    private final HoursWorked invalidRemovedHoursWorked = new HoursWorked("100");
+    private final Overtime invalidRemovedOvertime = new Overtime("100");
 
     private Person createPersonWithHoursRemoved(Person personToRemoveHoursFrom, HoursWorked hoursWorked,
                                                 Overtime overtime) {
@@ -72,8 +72,12 @@ public class DeductHoursWorkedCommandTest {
         Person personWithRemovedHours =
                 createPersonWithHoursRemoved(personToRemoveHoursFrom, removedHoursWorked, removedOvertime);
 
-        String expectedMessage =
-                String.format(DeductHoursWorkedCommand.MESSAGE_SUCCESS, personWithRemovedHours);
+        String expectedMessage = String.format(DeductHoursWorkedCommand.MESSAGE_SUCCESS,
+                        personWithRemovedHours.getName().toString(),
+                        personWithRemovedHours.getHoursWorked().toString(),
+                        personWithRemovedHours.getHoursWorked().toString().equals("1") ? "" : "s",
+                        personWithRemovedHours.getOvertime().toString(),
+                        personWithRemovedHours.getOvertime().toString().equals("1") ? "" : "s");
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.setPerson(personToRemoveHoursFrom, personWithRemovedHours);
@@ -101,8 +105,12 @@ public class DeductHoursWorkedCommandTest {
         Person personWithRemovedHours =
                 createPersonWithHoursRemoved(personToRemoveHoursFrom, removedHoursWorked, removedOvertime);
 
-        String expectedMessage =
-                String.format(DeductHoursWorkedCommand.MESSAGE_SUCCESS, personWithRemovedHours);
+        String expectedMessage = String.format(DeductHoursWorkedCommand.MESSAGE_SUCCESS,
+                personWithRemovedHours.getName().toString(),
+                personWithRemovedHours.getHoursWorked().toString(),
+                personWithRemovedHours.getHoursWorked().toString().equals("1") ? "" : "s",
+                personWithRemovedHours.getOvertime().toString(),
+                personWithRemovedHours.getOvertime().toString().equals("1") ? "" : "s");
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
@@ -129,18 +137,30 @@ public class DeductHoursWorkedCommandTest {
     public void execute_notEnoughHoursWorked_throwsCommandException() {
         DeductHoursWorkedCommand deductHoursWorkedCommand =
                 new DeductHoursWorkedCommand(INDEX_FIRST_PERSON, invalidRemovedHoursWorked, removedOvertime);
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
         assertCommandFailure(deductHoursWorkedCommand, model,
-                String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT, invalidRemovedHoursWorked, "hours worked"));
+                String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT,
+                        invalidRemovedHoursWorked.toString(),
+                        invalidRemovedHoursWorked.toString().equals("1") ? "hour worked" : "hours worked",
+                        firstPerson.getHoursWorked().toString(),
+                        firstPerson.getHoursWorked().toString().equals("1") ? "hour worked" : "hours worked"));
     }
 
     @Test
     public void execute_notEnoughOvertime_throwsCommandException() {
         DeductHoursWorkedCommand deductHoursWorkedCommand =
                 new DeductHoursWorkedCommand(INDEX_FIRST_PERSON, removedHoursWorked, invalidRemovedOvertime);
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
         assertCommandFailure(deductHoursWorkedCommand, model,
-                String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT, invalidRemovedOvertime, "overtime hours"));
+                String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT,
+                        invalidRemovedOvertime.toString(),
+                        invalidRemovedOvertime.toString().equals("1")
+                                ? "overtime hour worked" : "overtime hours worked",
+                        firstPerson.getOvertime().toString(),
+                        firstPerson.getOvertime().toString().equals("1")
+                                ? "overtime hour worked" : "overtime hours worked"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeductLeaveBalanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeductLeaveBalanceCommandTest.java
@@ -37,7 +37,7 @@ import seedu.address.model.tag.Tag;
 public class DeductLeaveBalanceCommandTest {
     private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private final LeaveBalance removedLeaves = new LeaveBalance("3");
-    private final LeaveBalance invalidRemovedLeaves = new LeaveBalance("1000");
+    private final LeaveBalance invalidRemovedLeaves = new LeaveBalance("100");
 
     private Person createPersonWithRemovedLeaves(Person personToRemoveLeavesFrom, LeaveBalance removedLeaves) {
         Name name = personToRemoveLeavesFrom.getName();
@@ -66,8 +66,10 @@ public class DeductLeaveBalanceCommandTest {
 
         Person personWithRemovedLeaves = createPersonWithRemovedLeaves(personToRemoveLeavesFrom, removedLeaves);
 
-        String expectedMessage =
-                String.format(DeductLeaveBalanceCommand.MESSAGE_SUCCESS, personWithRemovedLeaves);
+        String expectedMessage = String.format(DeductLeaveBalanceCommand.MESSAGE_SUCCESS,
+                personWithRemovedLeaves.getName().toString(),
+                personWithRemovedLeaves.getLeaveBalance().toString(),
+                personWithRemovedLeaves.getLeaveBalance().toString().equals("1") ? "" : "s");
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.setPerson(personToRemoveLeavesFrom, personWithRemovedLeaves);
@@ -94,8 +96,10 @@ public class DeductLeaveBalanceCommandTest {
 
         Person personWithRemovedLeaves = createPersonWithRemovedLeaves(personToRemoveLeavesFrom, removedLeaves);
 
-        String expectedMessage =
-                String.format(DeductLeaveBalanceCommand.MESSAGE_SUCCESS, personWithRemovedLeaves);
+        String expectedMessage = String.format(DeductLeaveBalanceCommand.MESSAGE_SUCCESS,
+                personWithRemovedLeaves.getName().toString(),
+                personWithRemovedLeaves.getLeaveBalance().toString(),
+                personWithRemovedLeaves.getLeaveBalance().toString().equals("1") ? "" : "s");
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
@@ -122,9 +126,14 @@ public class DeductLeaveBalanceCommandTest {
     public void execute_notEnoughLeaves_throwsCommandException() {
         DeductLeaveBalanceCommand deductLeaveBalanceCommand =
                 new DeductLeaveBalanceCommand(INDEX_FIRST_PERSON, invalidRemovedLeaves);
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
         assertCommandFailure(deductLeaveBalanceCommand, model,
-                String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT, invalidRemovedLeaves, "leaves"));
+                String.format(Messages.MESSAGE_INVALID_REMOVE_INPUT,
+                        invalidRemovedLeaves.toString(),
+                        invalidRemovedLeaves.toString().equals("1") ? "leave" : "leaves",
+                        firstPerson.getLeaveBalance().toString(),
+                        firstPerson.getLeaveBalance().toString().equals("1") ? "leave" : "leaves"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -31,7 +31,8 @@ public class DeleteCommandTest {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_EMPLOYEE_SUCCESS, personToDelete);
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_EMPLOYEE_SUCCESS,
+                personToDelete.getName().toString());
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
@@ -54,7 +55,8 @@ public class DeleteCommandTest {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_EMPLOYEE_SUCCESS, personToDelete);
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_EMPLOYEE_SUCCESS,
+                personToDelete.getName().toString());
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -31,7 +31,7 @@ public class DeleteCommandTest {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_EMPLOYEE_SUCCESS, personToDelete);
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
@@ -54,7 +54,7 @@ public class DeleteCommandTest {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_EMPLOYEE_SUCCESS, personToDelete);
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);

--- a/src/test/java/seedu/address/logic/commands/PayCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/PayCommandTest.java
@@ -91,7 +91,9 @@ public class PayCommandTest {
 
         Person paidPerson = createPaidPerson(personToPay);
 
-        String expectedMessage = String.format(PayCommand.MESSAGE_PAY_PERSON_SUCCESS, paidPerson);
+        String expectedMessage = String.format(PayCommand.MESSAGE_PAY_PERSON_SUCCESS,
+                personToPay.getCalculatedPay().toString(),
+                paidPerson.getName().toString());
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.setPerson(personToPay, paidPerson);

--- a/src/test/java/seedu/address/logic/parser/AddLeaveBalanceCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddLeaveBalanceCommandParserTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_INTEGER_INPUT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_LEAVES_INPUT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LEAVE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -46,7 +46,7 @@ public class AddLeaveBalanceCommandParserTest {
 
     @Test
     public void parse_invalidInteger_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_INTEGER_INPUT, AddLeaveBalanceCommand.MESSAGE_USAGE);
+        String expectedMessage = String.format(MESSAGE_INVALID_LEAVES_INPUT, AddLeaveBalanceCommand.MESSAGE_USAGE);
         String userInput = INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_LEAVE;
 
         // Not an integer

--- a/src/test/java/seedu/address/logic/parser/DeductLeaveBalanceCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeductLeaveBalanceCommandParserTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_INTEGER_INPUT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_LEAVES_INPUT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LEAVE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -46,7 +46,7 @@ public class DeductLeaveBalanceCommandParserTest {
 
     @Test
     public void parse_invalidInteger_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_INTEGER_INPUT, DeductLeaveBalanceCommand.MESSAGE_USAGE);
+        String expectedMessage = String.format(MESSAGE_INVALID_LEAVES_INPUT, DeductLeaveBalanceCommand.MESSAGE_USAGE);
         String userInput = INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_LEAVE;
 
         // Not an integer

--- a/src/test/java/seedu/address/model/person/HoursWorkedTest.java
+++ b/src/test/java/seedu/address/model/person/HoursWorkedTest.java
@@ -43,8 +43,12 @@ public class HoursWorkedTest {
         assertFalse(HoursWorked.isValidHoursWorked("7h")); // contains alphanumeric characters
         assertFalse(HoursWorked.isValidHoursWorked("-1")); // contains negative values
         assertFalse(HoursWorked.isValidHoursWorked("1.1")); // contains floating point values
+        assertFalse(HoursWorked.isValidHoursWorked("12345")); // exceeds max bound
 
         // valid hoursWorked
-        assertTrue(HoursWorked.isValidHoursWorked("12345")); // numeric characters as integers only
+        assertTrue(HoursWorked.isValidHoursWorked("365")); // max boundary
+        assertTrue(HoursWorked.isValidHoursWorked("0")); // min boundary
+        assertTrue(HoursWorked.isValidHoursWorked("100")); // value inside equivalence partition
+        assertTrue(HoursWorked.isValidHoursWorked("201")); // value inside equivalence partition
     }
 }


### PR DESCRIPTION
Added error checking for LeaveBalance, HoursWorked, and Overtime as well as related classes (Command and CommandParser). LeaveBalance is bounded between 0 and 365 inclusive, while HoursWorked and Overtime are bounded between 0 and 744 (24 hours * 31 days) inclusive. (Resolves #153, resolves #161, resolves #174)
Added error checking to ensure that addHoursWorked and deductHoursWorked throws an error if hours worked is valid but overtime is invalid (and vice-versa). (Resolves #163)
Updated all success messages to contain only relevant information (Resolves #137)
Find now auto selects the first person in the filtered list, and displays an example person if the filtered list is empty (Resolves #162) 
Also changed various mentions of address book to HeRon, and person to employee.
(Potential new bug/feature flaw?: Changing a person in a filtered list causes them to disappear if the updated person fails the predicate. E.g. find l/=1, then adding/removing leaves causes the person to disappear from the list. The person in the info panel is the updated person, although they have disappeared from the list already.)